### PR TITLE
release: 0.1.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokcat",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokcat",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@react-three/drei": "^9.117.3",
         "@react-three/fiber": "^8.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "tokcat"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary
- bump package, Tauri, and Cargo versions to 0.1.23
- refresh npm and Cargo lockfiles for the release tag

## Release notes
- Prevent tray animation stutter by disabling implicit Core Animation layer actions during frame swaps and refresh hops.
- Refresh README for live tokens/min, Live trace, and current tray animation settings.
- Include the redesigned GitHub Pages landing page.

## Validation
- npm ci
- npx tsc --noEmit
- npm run build
- cargo check
- cargo check --locked
- git diff --check