### PR TITLE
Release Tokcat 0.1.26 — center-aligned usage stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4289,7 +4289,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/src/styles.css
+++ b/src/styles.css
@@ -716,6 +716,9 @@ html, body, #root {
 .bar2d-stats {
   margin: 2px 0 12px;
 }
+.bar2d-stats .usage-cell {
+  text-align: center;
+}
 .bar2d-chart {
   position: relative;
 }


### PR DESCRIPTION
Center-align the Total / Tokens / Best day stat columns in the combined usage card. Bumps to 0.1.26; tag v0.1.26 follows to trigger the release workflow.