### PR TITLE
Fix menubar popover across macOS spaces

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -124,11 +124,14 @@ pub fn toggle_popover<R: Runtime>(app: &AppHandle<R>) {
         if w.is_visible().unwrap_or(false) {
             hide_popover(app);
         } else {
+            prepare_popover_window(&w);
             if let Some(tray) = app.tray_by_id("main-tray") {
                 let _ = position_window_under_tray(&tray, &w);
             }
             let _ = w.show();
+            bring_popover_to_front(&w);
             let _ = w.set_focus();
+            bring_popover_to_front(&w);
             let _ = app.emit("popover-shown", ());
         }
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -83,15 +83,21 @@ pub fn setup<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                     if visible {
                         hide_popover(app);
                     } else {
+                        prepare_popover_window(&w);
                         let _ = position_window_under_tray(tray, &w);
                         let _ = w.show();
+                        bring_popover_to_front(&w);
                         let _ = w.set_focus();
+                        bring_popover_to_front(&w);
                         let _ = app.emit("popover-shown", ());
                     }
                 }
             }
         })
         .build(app)?;
+    if let Some(w) = app.get_webview_window("main") {
+        prepare_popover_window(&w);
+    }
     Ok(())
 }
 
@@ -130,14 +136,58 @@ pub fn toggle_popover<R: Runtime>(app: &AppHandle<R>) {
 
 fn show_popover<R: Runtime>(app: &AppHandle<R>) {
     if let Some(w) = app.get_webview_window("main") {
+        prepare_popover_window(&w);
         if let Some(tray) = app.tray_by_id("main-tray") {
             let _ = position_window_under_tray(&tray, &w);
         }
         let _ = w.show();
+        bring_popover_to_front(&w);
         let _ = w.set_focus();
+        bring_popover_to_front(&w);
         let _ = app.emit("popover-shown", ());
     }
 }
+
+#[cfg(target_os = "macos")]
+fn prepare_popover_window<R: Runtime>(window: &WebviewWindow<R>) {
+    use objc2_app_kit::{NSPopUpMenuWindowLevel, NSWindow, NSWindowCollectionBehavior};
+
+    let _ = window.set_visible_on_all_workspaces(true);
+
+    let Ok(ns_window) = window.ns_window() else {
+        return;
+    };
+
+    let ns_window = unsafe { &*(ns_window.cast::<NSWindow>()) };
+    let behavior = ns_window.collectionBehavior()
+        | NSWindowCollectionBehavior::CanJoinAllSpaces
+        | NSWindowCollectionBehavior::CanJoinAllApplications
+        | NSWindowCollectionBehavior::FullScreenAuxiliary
+        | NSWindowCollectionBehavior::IgnoresCycle
+        | NSWindowCollectionBehavior::Transient;
+    ns_window.setCollectionBehavior(behavior);
+    ns_window.setLevel(NSPopUpMenuWindowLevel);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn prepare_popover_window<R: Runtime>(window: &WebviewWindow<R>) {
+    let _ = window.set_visible_on_all_workspaces(true);
+}
+
+#[cfg(target_os = "macos")]
+fn bring_popover_to_front<R: Runtime>(window: &WebviewWindow<R>) {
+    use objc2_app_kit::NSWindow;
+
+    let Ok(ns_window) = window.ns_window() else {
+        return;
+    };
+
+    let ns_window = unsafe { &*(ns_window.cast::<NSWindow>()) };
+    ns_window.orderFrontRegardless();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn bring_popover_to_front<R: Runtime>(_window: &WebviewWindow<R>) {}
 
 fn position_window_under_tray<R: Runtime>(
     tray: &tauri::tray::TrayIcon<R>,
@@ -166,8 +216,9 @@ fn position_window_under_tray<R: Runtime>(
         .unwrap_or(POPOVER_DEFAULT_H)
         .clamp(POPOVER_MIN_H, POPOVER_MAX_H);
 
-    // Clamp to monitor bounds
-    if let Ok(Some(monitor)) = window.current_monitor() {
+    // Clamp to the monitor that owns the tray icon, not the monitor remembered
+    // by the hidden popover window from its last Space.
+    if let Ok(Some(monitor)) = window.monitor_from_point(tray_x_logical, tray_y_logical) {
         let m_pos = monitor.position();
         let m_size = monitor.size();
         let m_scale = monitor.scale_factor();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
         "alwaysOnTop": false,
         "skipTaskbar": true,
         "visible": false,
+        "visibleOnAllWorkspaces": true,
         "center": true,
         "shadow": true,
         "windowEffects": {


### PR DESCRIPTION
## Background

Tokcat is a macOS menubar app, so the main window behaves like a popover rather than a regular desktop window. Before this change, the first Space that opened the popover could effectively become the window's remembered Space. When the user clicked the menu bar icon from another Space, macOS could switch back to the original Space instead of opening Tokcat where the click happened.

Full-screen app Spaces had a second failure mode: after preventing the Space switch, the popover could still fail to appear because it was not ordered above the full-screen app window.

> Expected behavior: when the user clicks the Tokcat menu bar icon, the popover should open in the current macOS Space, including regular desktop Spaces and full-screen app Spaces.

## Problem Matrix

| Scenario | Previous behavior | Expected behavior |
|---|---|---|
| First open in Space A | Popover appears normally | Popover appears normally |
| Switch to Space B and click the menu bar icon | macOS may jump back to Space A | Stay in Space B and show the popover |
| Click from a full-screen app Space | The app may stay in place, but the popover may not appear | Stay in the full-screen Space and show the popover in front |
| Multi-monitor or hidden-window reuse | Positioning may follow the hidden window's last monitor | Position from the clicked tray icon's monitor |

## Root Cause

This is not a React state issue. It comes from AppKit's native management of `NSWindow`, Spaces, and full-screen Spaces.

```mermaid
flowchart TD
    CLICK[User clicks menu bar icon] --> SHOW[Tauri shows main WebviewWindow]
    SHOW --> SPACE{Which Space owns the window?}
    SPACE -->|Reusable hidden window| OLD[macOS may return to the original Space]
    SPACE -->|Only joins all regular Spaces| FS[Full-screen Space may not order the window in front]
    OLD --> BAD[User is moved away from the current Space]
    FS --> HIDDEN[Popover exists but is not visible above the full-screen app]
```

| Cause | Details |
|---|---|
| Reused hidden window | Tokcat reuses the same `main` WebviewWindow. After `hide()`, a later `show()` can preserve the original Space relationship. |
| `set_focus()` is not enough for full-screen Spaces | Full-screen apps use dedicated Spaces, and normal focus/order behavior may not bring an accessory app window forward there. |
| Monitor lookup used window state | `current_monitor()` can reflect the hidden window's previous location instead of the menu bar icon that was clicked. |

## Implementation

| File | Change | Purpose |
|---|---|---|
| `src-tauri/tauri.conf.json` | Add `visibleOnAllWorkspaces: true` | Set the cross-Space intent when the Tauri window is created. |
| `src-tauri/src/tray.rs` | Call `prepare_popover_window()` before showing the popover | Reapply native macOS window behavior every time the popover opens. |
| `src-tauri/src/tray.rs` | Add `CanJoinAllSpaces`, `CanJoinAllApplications`, `FullScreenAuxiliary`, `IgnoresCycle`, and `Transient` | Allow the popover to participate in regular Spaces and full-screen app Spaces while keeping popover-like behavior. |
| `src-tauri/src/tray.rs` | Set `NSPopUpMenuWindowLevel` | Use a window level appropriate for menu/popover UI so it appears above full-screen app content. |
| `src-tauri/src/tray.rs` | Call `orderFrontRegardless()` after `show()` and `set_focus()` | Force the popover to the foreground in full-screen Spaces. |
| `src-tauri/src/tray.rs` | Use `monitor_from_point(tray_x, tray_y)` instead of `current_monitor()` | Position relative to the clicked menu bar icon, not the hidden window's previous monitor. |

## Open Flow

```mermaid
flowchart TD
    CLICK[Menu bar icon click] --> GETWIN[Get main WebviewWindow]
    GETWIN --> VISIBLE{Is it visible?}
    VISIBLE -->|Yes| HIDE[Hide popover]
    VISIBLE -->|No| PREP[prepare_popover_window]
    PREP --> POSITION[Position from tray rect and tray monitor]
    POSITION --> SHOW[window.show]
    SHOW --> FRONT1[orderFrontRegardless]
    FRONT1 --> FOCUS[set_focus]
    FOCUS --> FRONT2[orderFrontRegardless]
    FRONT2 --> EVENT[emit popover-shown]
```

## Verification

| Check | Result |
|---|---|
| Rust formatting | Passed |
| Tauri debug build | Passed with existing vendored/native warnings |
| macOS app bundle | Passed and produced a debug `Tokcat.app` |
| Manual regular Space test | Passed; macOS no longer jumps back to Space A |
| Manual full-screen Space test | Passed; the popover appears in the current full-screen Space |

Commands run locally:

```bash
rustfmt --check src/tray.rs
npx tauri build --debug --no-bundle
npx tauri build --debug --bundles app --no-sign --config '{"bundle":{"createUpdaterArtifacts":false}}'
```

Manual test coverage:

| Scenario | Result |
|---|---|
| Open in Space A, switch to Space B, click the menu bar icon | Passed; the current Space is preserved |
| Enter a macOS full-screen app Space and click the menu bar icon | Passed; the popover appears in that full-screen Space |

> **Note:** The app-bundle command disables signing and updater artifacts only for local verification. The normal release pipeline should keep using the existing signing and updater artifact flow.

## Risk And Tradeoffs

| Area | Assessment |
|---|---|
| Platform scope | Native behavior is guarded by `#[cfg(target_os = "macos")]`; non-macOS keeps the existing `set_visible_on_all_workspaces(true)` path. |
| Window level | `NSPopUpMenuWindowLevel` matches menu/popover UI and fixes foreground ordering in full-screen Spaces. |
| AppKit surface area | The change uses Tauri's `ns_window()` handle and objc2 AppKit APIs without modifying Tauri runtime or vendored tray-icon code. |
| UX behavior | `IgnoresCycle` and `Transient` keep the popover out of normal window cycling, matching expected menubar-popover behavior. |

## Implementation Summary

```text
src-tauri/src/tray.rs
├── prepare_popover_window()
│   ├── set_visible_on_all_workspaces(true)
│   ├── setCollectionBehavior(...FullScreenAuxiliary...)
│   └── setLevel(NSPopUpMenuWindowLevel)
├── bring_popover_to_front()
│   └── orderFrontRegardless()
└── position_window_under_tray()
    └── monitor_from_point(tray_x, tray_y)
```

## Issue

Fixes #13

