### PR TITLE
Release Tokcat 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4332,7 +4332,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1214,6 +1214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1347,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2890,7 +2918,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4026,6 +4054,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,6 +4355,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tokio",
@@ -5658,6 +5702,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5666,6 +5727,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ env_logger = "0.11"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-process = "2"
+tauri-plugin-global-shortcut = "2"
 # Bundled SQLite so we don't depend on the system libsqlite3; needed for
 # the Hermes Agent SQLite tail in usage_tail.rs (no schema migrations —
 # read-only queries only).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,14 @@ fn quit_app(app: tauri::AppHandle) {
     app.exit(0);
 }
 
+/// Hide the popover from the frontend (⌘W / Esc) and return focus to the
+/// previously-frontmost app. Routed through the same helper as the tray-click
+/// and Ctrl+Cmd+T toggle so every explicit dismiss behaves identically.
+#[tauri::command]
+fn hide_popover(app: tauri::AppHandle) {
+    tray::hide_popover(&app);
+}
+
 #[tauri::command]
 fn push_dialog_shield(state: tauri::State<'_, Arc<AppState>>) {
     state.push_suppress_blur_hide();
@@ -299,6 +307,12 @@ pub fn run() {
     let state = AppState::new();
     let state_clone = state.clone();
 
+    // Ctrl+Cmd+T toggles the popover from anywhere — registered in setup, fired
+    // by the plugin handler below. Shortcut is Copy, so the same value is reused
+    // for both the handler match and the setup-time registration.
+    use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+    let toggle_shortcut = Shortcut::new(Some(Modifiers::CONTROL | Modifiers::SUPER), Code::KeyT);
+
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -307,11 +321,21 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(move |app, shortcut, event| {
+                    if shortcut == &toggle_shortcut && event.state() == ShortcutState::Pressed {
+                        tray::toggle_popover(app);
+                    }
+                })
+                .build(),
+        )
         .manage(state.clone())
         .invoke_handler(tauri::generate_handler![
             get_graph,
             refresh_graph,
             quit_app,
+            hide_popover,
             push_dialog_shield,
             pop_dialog_shield,
             set_animate_tray,
@@ -331,6 +355,12 @@ pub fn run() {
         }
         let handle = app.handle().clone();
         tray::setup(&handle)?;
+        {
+            use tauri_plugin_global_shortcut::GlobalShortcutExt;
+            if let Err(e) = app.global_shortcut().register(toggle_shortcut) {
+                log::warn!("global shortcut register failed: {}", e);
+            }
+        }
         #[cfg(target_os = "macos")]
         if let Err(e) = native_tray::init() {
             log::warn!(

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -81,7 +81,7 @@ pub fn setup<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 if let Some(w) = app.get_webview_window("main") {
                     let visible = w.is_visible().unwrap_or(false);
                     if visible {
-                        let _ = w.hide();
+                        hide_popover(app);
                     } else {
                         let _ = position_window_under_tray(tray, &w);
                         let _ = w.show();
@@ -93,6 +93,39 @@ pub fn setup<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         })
         .build(app)?;
     Ok(())
+}
+
+/// Hide the popover and hand keyboard focus back to the app that was in front
+/// before it opened. Plain `w.hide()` (orderOut) leaves Tokcat the active
+/// accessory app with no window, so focus lands nowhere; `app.hide()` (NSApp
+/// hide) deactivates Tokcat and reactivates the previously-frontmost app. The
+/// `w.hide()` runs first so the toggle's `is_visible()` check is reliable
+/// regardless of how NSApp hide reports window visibility. Used by every
+/// explicit dismiss (Ctrl+Cmd+T, tray-click toggle, ⌘W, Esc) but not the
+/// blur-hide, where focus has already moved to whatever stole it.
+pub fn hide_popover<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.hide();
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app.hide();
+}
+
+/// Show the popover under the tray if hidden, hide it if visible. Mirrors the
+/// left-click tray toggle so the global shortcut (Ctrl+Cmd+T) behaves the same.
+pub fn toggle_popover<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(w) = app.get_webview_window("main") {
+        if w.is_visible().unwrap_or(false) {
+            hide_popover(app);
+        } else {
+            if let Some(tray) = app.tray_by_id("main-tray") {
+                let _ = position_window_under_tray(&tray, &w);
+            }
+            let _ = w.show();
+            let _ = w.set_focus();
+            let _ = app.emit("popover-shown", ());
+        }
+    }
 }
 
 fn show_popover<R: Runtime>(app: &AppHandle<R>) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,12 @@ export default function App() {
 
   const [aboutOpen, setAboutOpen] = useState(false)
   const [appVersion, setAppVersion] = useState('')
+  // True while the Cmd key is held — drives the translucent shortcut-hint pins
+  // overlaid on each actionable control (⌘R, ⌘,, ⌘1…, ⌘G).
+  const [cmdHeld, setCmdHeld] = useState(false)
+  // True while a manual refresh (button / ⌘R / tray) is in flight — spins the
+  // header refresh icon so the fetch is visible even when it returns instantly.
+  const [refreshing, setRefreshing] = useState(false)
 
   useEffect(() => {
     saveSettings(settings)
@@ -150,16 +156,25 @@ export default function App() {
     return () => window.clearInterval(id)
   }, [])
 
-  // Manual refresh from tray menu — bypasses cache.
+  // Manual refresh from the header button, ⌘R, or the tray menu — bypasses
+  // cache. Drives `refreshing` for the whole fetch so the header icon spins;
+  // refresh_graph holds a ~450ms floor, so the spin is always visible.
   useEffect(() => {
     if (refreshTick === 0) return
-    if (!isTauri()) return
+    setRefreshing(true)
+    if (!isTauri()) {
+      const id = window.setTimeout(() => setRefreshing(false), 600)
+      return () => window.clearTimeout(id)
+    }
+    let done = false
     ;(async () => {
       try {
         const { invoke } = await import('@tauri-apps/api/core')
         await invoke('refresh_graph', { year })
       } catch {}
+      if (!done) setRefreshing(false)
     })()
+    return () => { done = true }
   }, [refreshTick, year])
 
   const allYears = useMemo(() => {
@@ -184,6 +199,103 @@ export default function App() {
     if (activeTab === 'overview') return
     if (!dashboardClients.includes(activeTab)) setActiveTab('overview')
   }, [activeTab, dashboardClients])
+
+  // Internal keyboard shortcuts. The global Ctrl+Cmd+T popover toggle is
+  // registered natively in Rust; everything here is cmd-only and cmd-exclusive
+  // (ctrl/alt/shift held → ignored) so it never collides with that global key.
+  useEffect(() => {
+    const tabs = ['overview', ...dashboardClients]
+
+    async function hidePopover() {
+      if (!isTauri()) return
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        await invoke('hide_popover')
+      } catch {}
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Esc closes the top-most modal first, else hides the popover. Skipped
+      // when a form control is focused so Esc can dismiss its native dropdown.
+      if (e.key === 'Escape') {
+        const tag = document.activeElement?.tagName
+        if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA') return
+        if (settingsOpen) { setSettingsOpen(false); e.preventDefault(); return }
+        if (aboutOpen) { setAboutOpen(false); e.preventDefault(); return }
+        void hidePopover()
+        e.preventDefault()
+        return
+      }
+
+      if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return
+      const k = e.key.toLowerCase()
+
+      if (k >= '1' && k <= '9') {
+        const idx = Number(k) - 1
+        if (idx < tabs.length) { setActiveTab(tabs[idx]); e.preventDefault() }
+        return
+      }
+
+      switch (k) {
+        case ',':
+          setSettingsOpen(true); e.preventDefault(); break
+        case 'r':
+          setRefreshTick(t => t + 1); e.preventDefault(); break
+        case 'w':
+          // Mirror Esc: close the top-most modal first, only hide the popover
+          // when nothing is open over it.
+          if (settingsOpen) setSettingsOpen(false)
+          else if (aboutOpen) setAboutOpen(false)
+          else void hidePopover()
+          e.preventDefault(); break
+        case 'q':
+          if (isTauri()) {
+            ;(async () => {
+              try {
+                const { invoke } = await import('@tauri-apps/api/core')
+                await invoke('quit_app')
+              } catch {}
+            })()
+          }
+          e.preventDefault(); break
+        case 'g':
+          setUsageView(v => (v === '2d' ? '3d' : '2d')); e.preventDefault(); break
+        case 'u':
+          if (isTauri()) void checkForUpdatesInteractive()
+          e.preventDefault(); break
+        case '[': {
+          const i = tabs.indexOf(activeTab)
+          setActiveTab(tabs[(i - 1 + tabs.length) % tabs.length]); e.preventDefault(); break
+        }
+        case ']': {
+          const i = tabs.indexOf(activeTab)
+          setActiveTab(tabs[(i + 1) % tabs.length]); e.preventDefault(); break
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [dashboardClients, activeTab, settingsOpen, aboutOpen])
+
+  // Track the Cmd key for the shortcut-hint overlay. keyup can be missed if the
+  // app loses focus mid-hold (e.g. Cmd+Tab), so blur/visibilitychange force the
+  // pins off — otherwise they'd stay stuck after switching away.
+  useEffect(() => {
+    const onDown = (e: KeyboardEvent) => { if (e.key === 'Meta') setCmdHeld(true) }
+    const onUp = (e: KeyboardEvent) => { if (e.key === 'Meta') setCmdHeld(false) }
+    const reset = () => setCmdHeld(false)
+    window.addEventListener('keydown', onDown)
+    window.addEventListener('keyup', onUp)
+    window.addEventListener('blur', reset)
+    document.addEventListener('visibilitychange', reset)
+    return () => {
+      window.removeEventListener('keydown', onDown)
+      window.removeEventListener('keyup', onUp)
+      window.removeEventListener('blur', reset)
+      document.removeEventListener('visibilitychange', reset)
+    }
+  }, [])
 
   const overviewClientSet = useMemo(() => new Set(presentClients), [presentClients])
   const activeClientIds = useMemo(
@@ -357,8 +469,10 @@ export default function App() {
                 onThemeChange={(t) => setTheme(t as ThemeName)}
                 onRefresh={() => setRefreshTick(t => t + 1)}
                 onOpenSettings={() => setSettingsOpen(true)}
+                kbdHints={cmdHeld}
+                refreshing={refreshing}
               />
-              <DashboardTabs clients={dashboardClients} active={activeTab} onChange={setActiveTab} />
+              <DashboardTabs clients={dashboardClients} active={activeTab} onChange={setActiveTab} kbdHints={cmdHeld} />
               {activeTab === 'overview' ? (
                 <div className="dashboard-stack">
                   <UsageBarGraph2D
@@ -373,6 +487,7 @@ export default function App() {
                     graphDark={palette.graphDark}
                     accent={mode.accent}
                     stats={overviewStats}
+                    kbdHints={cmdHeld}
                   />
                   <AgentLimitsCard clients={dashboardClients} trace={trace} agentUsage={agentUsage.payload} />
                   <UsageTraceCard
@@ -404,6 +519,7 @@ export default function App() {
                     graphDark={palette.graphDark}
                     accent={mode.accent}
                     stats={activeStats}
+                    kbdHints={cmdHeld}
                   />
                   <StreaksCard longest={activeStats.streaks.longest} current={activeStats.streaks.current} />
                 </div>

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -5,6 +5,7 @@ interface Props {
   clients: string[]
   active: string
   onChange: (tab: string) => void
+  kbdHints?: boolean
 }
 
 function ClientMark({ id }: { id: string }) {
@@ -26,7 +27,10 @@ function ClientMark({ id }: { id: string }) {
   )
 }
 
-export function DashboardTabs({ clients, active, onChange }: Props) {
+export function DashboardTabs({ clients, active, onChange, kbdHints }: Props) {
+  // ⌘1 = Overview, ⌘2… = clients, matching the keyboard handler in App. Only
+  // the first nine tabs get a hint since ⌘0 is unbound.
+  const hint = (idx: number) => (kbdHints && idx < 9 ? `⌘${idx + 1}` : null)
   return (
     <div className="dash-tabs" role="tablist" aria-label="Dashboard sections">
       <button
@@ -43,10 +47,12 @@ export function DashboardTabs({ clients, active, onChange }: Props) {
           <span />
         </span>
         <span>Overview</span>
+        {hint(0) && <span className="kbd-pin" aria-hidden="true">{hint(0)}</span>}
       </button>
-      {clients.map(id => {
+      {clients.map((id, i) => {
         const style = getClientStyle(id)
         const isActive = active === id
+        const h = hint(i + 1)
         return (
           <button
             key={id}
@@ -58,6 +64,7 @@ export function DashboardTabs({ clients, active, onChange }: Props) {
           >
             <ClientMark id={id} />
             <span>{style.displayName.replace(/\s+(CLI|Code|IDE)$/i, '')}</span>
+            {h && <span className="kbd-pin" aria-hidden="true">{h}</span>}
           </button>
         )
       })}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -11,9 +11,11 @@ interface Props {
   onThemeChange: (t: string) => void
   onRefresh?: () => void
   onOpenSettings?: () => void
+  kbdHints?: boolean
+  refreshing?: boolean
 }
 
-export function HeaderBar({ totalTokens, year, years, onYearChange, theme, onThemeChange, onRefresh, onOpenSettings }: Props) {
+export function HeaderBar({ totalTokens, year, years, onYearChange, theme, onThemeChange, onRefresh, onOpenSettings, kbdHints, refreshing }: Props) {
   return (
     <div className="header-bar" data-tauri-drag-region>
       <div className="header-brand" data-tauri-drag-region>
@@ -36,12 +38,13 @@ export function HeaderBar({ totalTokens, year, years, onYearChange, theme, onThe
         </select>
         {onRefresh && (
           <button className="settings-btn" onClick={onRefresh} aria-label="Refresh" title="Refresh">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg className={refreshing ? 'refresh-spin' : undefined} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="23 4 23 10 17 10" />
               <polyline points="1 20 1 14 7 14" />
               <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10" />
               <path d="M20.49 15A9 9 0 0 1 5.64 18.36L1 14" />
             </svg>
+            {kbdHints && <span className="kbd-pin" aria-hidden="true">⌘R</span>}
           </button>
         )}
         {onOpenSettings && (
@@ -50,6 +53,7 @@ export function HeaderBar({ totalTokens, year, years, onYearChange, theme, onThe
               <circle cx="12" cy="12" r="3" />
               <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
             </svg>
+            {kbdHints && <span className="kbd-pin" aria-hidden="true">⌘,</span>}
           </button>
         )}
       </div>

--- a/src/components/UsageBarGraph2D.tsx
+++ b/src/components/UsageBarGraph2D.tsx
@@ -21,6 +21,7 @@ interface Props {
   accent: string
   /** When provided, the card leads with these token-usage totals (shown in both 2D and 3D). */
   stats?: Stats
+  kbdHints?: boolean
 }
 
 interface Segment {
@@ -95,6 +96,7 @@ export function UsageBarGraph2D({
   graphDark,
   accent,
   stats,
+  kbdHints,
 }: Props) {
   const [hover, setHover] = useState<HoverState | null>(null)
   const headSubtitle = stats && view === '3d' ? 'Full year' : subtitle
@@ -160,6 +162,7 @@ export function UsageBarGraph2D({
         </div>
         <div className="bar2d-head-right">
           <div className="bar2d-viewtoggle" role="group" aria-label="Chart view">
+            {kbdHints && <span className="kbd-pin kbd-pin-toggle" aria-hidden="true">⌘G</span>}
             <button
               type="button"
               className={`bar2d-viewbtn${view === '2d' ? ' is-active' : ''}`}

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,6 +33,9 @@
   --control-border: rgba(0, 0, 0, 0.08);
   --control-active-bg: rgba(255, 255, 255, 0.95);
   --control-active-shadow: 0 1px 2px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.06);
+
+  --kbd-pin-bg: rgba(255, 255, 255, 0.74);
+  --kbd-pin-border: rgba(0, 0, 0, 0.14);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -69,6 +72,9 @@
     --control-border: rgba(255, 255, 255, 0.10);
     --control-active-bg: rgba(255, 255, 255, 0.18);
     --control-active-shadow: 0 1px 2px rgba(0, 0, 0, 0.30);
+
+    --kbd-pin-bg: rgba(28, 28, 30, 0.74);
+    --kbd-pin-border: rgba(255, 255, 255, 0.18);
   }
 }
 
@@ -200,6 +206,7 @@ html, body, #root {
   overflow-x: auto;
 }
 .dash-tab {
+  position: relative;
   min-width: 0;
   height: 42px;
   display: inline-flex;
@@ -691,6 +698,7 @@ html, body, #root {
   gap: 6px;
 }
 .bar2d-viewtoggle {
+  position: relative;
   display: inline-flex;
   gap: 2px;
   padding: 2px;
@@ -900,6 +908,7 @@ html, body, #root {
 
 /* Settings button + panel */
 .settings-btn {
+  position: relative;
   background: var(--control-bg);
   border: 0.5px solid var(--control-border);
   color: var(--text-secondary);
@@ -1227,4 +1236,54 @@ html, body, #root {
   font-weight: 600;
   color: var(--blue);
   text-align: right;
+}
+
+/* Translucent shortcut-hint pins, overlaid on each control while Cmd is held. */
+.kbd-pin {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  z-index: 20;
+  padding: 1.5px 5px;
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  color: var(--text);
+  background: var(--kbd-pin-bg);
+  border: 0.5px solid var(--kbd-pin-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  pointer-events: none;
+  animation: kbd-pin-in 0.12s ease-out;
+}
+/* The tab strip clips vertical overflow (overflow-x: auto), so tab pins sit
+   inside the tab's top-right corner instead of overhanging it. */
+.dash-tab .kbd-pin {
+  top: 3px;
+  right: 3px;
+}
+/* The view toggle is short and sits at the card's right edge, so float its pin
+   fully above (not overhanging) and right-align it to stay inside the card. */
+.kbd-pin-toggle {
+  top: auto;
+  right: 0;
+  bottom: calc(100% + 3px);
+}
+@keyframes kbd-pin-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to { opacity: 1; transform: scale(1); }
+}
+/* Spins the header refresh icon while a manual refresh is in flight, so the
+   fetch is visibly "working" even when it returns in well under a second. */
+.refresh-spin {
+  transform-origin: 50% 50%;
+  animation: refresh-spin 0.7s linear infinite;
+}
+@keyframes refresh-spin {
+  to { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Tokcat 0.1.28

### Keyboard shortcuts
- Global `Ctrl+Cmd+T` toggles the popover from anywhere (registered natively in Rust)
- In-popover, cmd-exclusive: `Cmd+,` settings · `Cmd+R` refresh · `Cmd+W`/`Esc` close · `Cmd+Q` quit · `Cmd+1`–`9` jump to tab · `Cmd+[` / `Cmd+]` prev/next tab · `Cmd+G` 2D/3D · `Cmd+U` updates
- Hold `Cmd` to reveal translucent shortcut-hint pins on each control

### Polish
- Refresh icon spins while a manual refresh is in flight
- Dismissing the popover (`Ctrl+Cmd+T` / tray / `Cmd+W` / `Esc`) returns focus to the previously frontmost app
- `Cmd+W` / `Esc` closes an open settings/about modal before it falls through to hiding the popover

Verified: `tsc` clean, `cargo check` clean, in-browser checks for the spin and modal-aware `Cmd+W`.