### PR TITLE
Prefer Claude Keychain credentials for quota lookup

### DIFF
--- a/src-tauri/src/agent_usage.rs
+++ b/src-tauri/src/agent_usage.rs
@@ -468,6 +468,10 @@ fn load_claude_credentials() -> Result<ClaudeCredentials, String> {
         return Ok(credentials);
     }
 
+    if let Some(raw) = load_claude_credentials_from_keychain()? {
+        return parse_claude_credentials_data(&raw);
+    }
+
     let credentials_path = claude_credentials_path();
     match fs::read_to_string(&credentials_path) {
         Ok(raw) => return parse_claude_credentials_data(&raw),
@@ -479,10 +483,6 @@ fn load_claude_credentials() -> Result<ClaudeCredentials, String> {
                 error
             ));
         }
-    }
-
-    if let Some(raw) = load_claude_credentials_from_keychain()? {
-        return parse_claude_credentials_data(&raw);
     }
 
     Err("Claude OAuth credentials not found. Run `claude` to authenticate.".to_string())


### PR DESCRIPTION
## Summary

This changes the Claude OAuth credential lookup order used by the Agent limits quota request.

| Before | After |
|---|---|
| Environment override → `~/.claude/.credentials.json` → macOS Keychain | Environment override → macOS Keychain → `~/.claude/.credentials.json` |

Fixes #16.

## Why

On macOS, Claude Code can have a fresh OAuth credential in Keychain while a legacy `~/.claude/.credentials.json` file still exists. Tokcat previously returned the file credential first, so the quota lookup could use a stale credential and show a Claude OAuth error even though Claude Code itself was authenticated.

> This only changes the Agent limits OAuth quota lookup. Local usage history still comes from local session logs.

## Verification

| Check | Result |
|---|---|
| `cargo check` | Passed |
| Local app install smoke test | Built and launched `/Applications/Tokcat.app` successfully during manual validation |
