### PR TITLE
Release Tokcat 0.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4332,7 +4332,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/src/usage_graph.rs
+++ b/src-tauri/src/usage_graph.rs
@@ -1890,6 +1890,7 @@ fn infer_provider(model: &str) -> &'static str {
         || model.contains("sonnet")
         || model.contains("opus")
         || model.contains("haiku")
+        || model.contains("fable")
     {
         "anthropic"
     } else if model.starts_with("gpt-")
@@ -2035,6 +2036,9 @@ fn bundled_price(model: &str, provider: &str) -> Price {
     let normalized = m.replace(['.', '_', ' '], "-");
     let terminal = normalized.rsplit('/').next().unwrap_or(&normalized);
 
+    if normalized.contains("fable") {
+        return Price::new(10.0, 50.0, 1.0, 12.5);
+    }
     if normalized.contains("opus-4-6-fast") || normalized.contains("opus-4-7-fast") {
         return Price::new(30.0, 150.0, 3.0, 37.5);
     }
@@ -2224,6 +2228,16 @@ mod tests {
 
     #[test]
     fn bundled_price_matches_current_claude_model_families() {
+        assert_price(
+            "claude-fable-5",
+            "anthropic",
+            Price::new(10.0, 50.0, 1.0, 12.5),
+        );
+        assert_price(
+            "claude-fable-5[1m]",
+            "anthropic",
+            Price::new(10.0, 50.0, 1.0, 12.5),
+        );
         assert_price(
             "claude-opus-4-7",
             "anthropic",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Release 0.1.30

- Add Claude Fable 5 bundled pricing ($10 input / $50 output per MTok, $1 cache read, $12.50 5m cache write) — launched 2026-06-09, verified against platform.claude.com pricing docs and models.dev
- Route fable model IDs to the anthropic provider
- Previously `claude-fable-5` usage fell through to the generic claude fallback ($3/$15) and was under-estimated