### PR TITLE
Fix Codex false-detection and add opt-in Cursor usage (#22)

### DIFF
--- a/src-tauri/src/agent_usage.rs
+++ b/src-tauri/src/agent_usage.rs
@@ -215,10 +215,42 @@ struct ClaudeRefreshResponse {
 
 pub async fn run() -> AgentUsagePayload {
     let generated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+    let mut agents = Vec::new();
+    if codex_is_configured() {
+        agents.push(fetch_codex().await);
+    }
+    if claude_is_configured() {
+        agents.push(fetch_claude().await);
+    }
     AgentUsagePayload {
         generated_at,
-        agents: vec![fetch_codex().await, fetch_claude().await],
+        agents,
     }
+}
+
+/// Whether Codex OAuth has been set up at all. A missing auth.json means Codex
+/// isn't installed / logged in, so we hide its tile rather than render a
+/// perpetual "not found" error. A present-but-broken auth.json still surfaces
+/// an error tile so the user knows to re-authenticate.
+fn codex_is_configured() -> bool {
+    codex_home().join("auth.json").exists()
+}
+
+/// Whether Claude OAuth has been set up at all, mirroring the lookup order in
+/// load_claude_credentials (env override, Keychain, credentials file).
+fn claude_is_configured() -> bool {
+    let env_token = std::env::var("TOKCAT_CLAUDE_OAUTH_TOKEN")
+        .or_else(|_| std::env::var("CODEXBAR_CLAUDE_OAUTH_TOKEN"))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if env_token.is_some() {
+        return true;
+    }
+    if matches!(load_claude_credentials_from_keychain(), Ok(Some(_))) {
+        return true;
+    }
+    claude_credentials_path().exists()
 }
 
 async fn fetch_codex() -> AgentUsageSnapshot {

--- a/src-tauri/src/agent_usage.rs
+++ b/src-tauri/src/agent_usage.rs
@@ -1158,6 +1158,32 @@ mod tests {
     use super::*;
 
     #[test]
+    fn codex_tile_gated_on_auth_json_presence() {
+        // The agent-limits panel hides Codex unless it's actually set up. The
+        // gate is the presence of auth.json under CODEX_HOME — a missing file
+        // means "not installed / not logged in" and the tile stays hidden.
+        let dir =
+            std::env::temp_dir().join(format!("tokcat-codex-cfg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("CODEX_HOME", &dir);
+
+        assert!(
+            !codex_is_configured(),
+            "no auth.json under CODEX_HOME => Codex not configured"
+        );
+
+        std::fs::write(dir.join("auth.json"), "{}").unwrap();
+        assert!(
+            codex_is_configured(),
+            "auth.json present => Codex configured"
+        );
+
+        std::env::remove_var("CODEX_HOME");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn maps_codex_primary_and_secondary_windows() {
         let now = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
         let rate_limit = CodexRateLimit {

--- a/src-tauri/src/cursor_usage.rs
+++ b/src-tauri/src/cursor_usage.rs
@@ -1,0 +1,252 @@
+//! Cursor usage fetcher (opt-in).
+//!
+//! Cursor — unlike every other client Tokcat reads — keeps no local token/cost
+//! ledger on disk; its usage lives server-side. This module fetches per-event
+//! usage from Cursor's dashboard API and writes a local JSON cache that
+//! `usage_graph::parse_cursor` reads, so the rest of the graph pipeline stays
+//! purely local and synchronous.
+//!
+//! Opt-in only: it makes a network request to cursor.com authenticated with the
+//! user's own Cursor session token, which breaks Tokcat's otherwise local-first
+//! guarantee. Gated behind a settings toggle (AppState::cursor_usage_enabled).
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use rusqlite::{Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const USAGE_EVENTS_URL: &str = "https://cursor.com/api/dashboard/get-filtered-usage-events";
+const PAGE_SIZE: i64 = 250;
+const HISTORY_DAYS: i64 = 400;
+const DAY_MS: i64 = 86_400_000;
+
+/// One usage event flattened to the fields the contribution graph needs.
+#[derive(Serialize, Deserialize)]
+pub struct CachedCursorEvent {
+    pub timestamp_ms: i64,
+    pub model: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cost: f64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CursorCache {
+    pub fetched_at_ms: i64,
+    pub events: Vec<CachedCursorEvent>,
+}
+
+#[derive(Deserialize)]
+struct FilteredUsageResponse {
+    #[serde(rename = "totalUsageEventsCount")]
+    total: Option<i64>,
+    #[serde(rename = "usageEventsDisplay")]
+    events: Option<Vec<RawEvent>>,
+}
+
+#[derive(Deserialize)]
+struct RawEvent {
+    timestamp: Option<String>,
+    model: Option<String>,
+    #[serde(rename = "tokenUsage")]
+    token_usage: Option<RawTokenUsage>,
+}
+
+#[derive(Deserialize)]
+struct RawTokenUsage {
+    #[serde(rename = "inputTokens")]
+    input_tokens: Option<i64>,
+    #[serde(rename = "outputTokens")]
+    output_tokens: Option<i64>,
+    #[serde(rename = "cacheReadTokens")]
+    cache_read_tokens: Option<i64>,
+    #[serde(rename = "totalCents")]
+    total_cents: Option<f64>,
+}
+
+fn home() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| "HOME is not set".to_string())
+}
+
+/// `~/.config/tokscale/cursor-cache/tokcat-events.json` — the same directory the
+/// legacy CSV cache lived in, so `usage_graph::parse_cursor` finds it.
+pub fn cache_path() -> Result<PathBuf, String> {
+    Ok(home()?
+        .join(".config")
+        .join("tokscale")
+        .join("cursor-cache")
+        .join("tokcat-events.json"))
+}
+
+fn state_db_path() -> Result<PathBuf, String> {
+    Ok(home()?.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb"))
+}
+
+/// Read Cursor's live OAuth access token from its Electron key/value store.
+/// Cursor refreshes this token in place; the macOS Keychain copy is only written
+/// at login and goes stale, so the state DB is the reliable source.
+fn read_access_token() -> Result<String, String> {
+    let path = state_db_path()?;
+    if !path.exists() {
+        return Err("Cursor not found. Install Cursor and sign in to enable usage.".to_string());
+    }
+    let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|e| format!("open Cursor state.vscdb: {}", e))?;
+    let token: String = conn
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|_| "Cursor session token not found. Open Cursor and sign in.".to_string())?;
+    let token = token.trim().trim_matches('"').trim().to_string();
+    if token.is_empty() {
+        return Err("Cursor session token is empty. Sign in to Cursor.".to_string());
+    }
+    Ok(token)
+}
+
+/// The token's `sub` claim doubles as the WorkOS user id in the session cookie.
+fn jwt_subject(token: &str) -> Result<String, String> {
+    let payload_b64 = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| "Cursor token is not a JWT".to_string())?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|e| format!("decode Cursor token payload: {}", e))?;
+    let claims: Value =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse Cursor token claims: {}", e))?;
+    claims
+        .get("sub")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| "Cursor token has no subject claim".to_string())
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Fetch all recent usage events from Cursor and rewrite the local JSON cache.
+/// Best-effort: returns a user-facing error string the toggle command can show.
+pub async fn refresh_cache() -> Result<(), String> {
+    let token = read_access_token()?;
+    let sub = jwt_subject(&token)?;
+    let cookie = format!("WorkosCursorSessionToken={}::{}", sub, token);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("build Cursor client: {}", e))?;
+
+    // Pad a day past "now" so today's events are always inside the window.
+    let end_ms = now_ms() + DAY_MS;
+    let start_ms = end_ms - HISTORY_DAYS * DAY_MS;
+
+    let mut events: Vec<CachedCursorEvent> = Vec::new();
+    let mut page = 1i64;
+    loop {
+        let body = serde_json::json!({
+            "teamId": 0,
+            "startDate": start_ms.to_string(),
+            "endDate": end_ms.to_string(),
+            "page": page,
+            "pageSize": PAGE_SIZE,
+        });
+        let resp = client
+            .post(USAGE_EVENTS_URL)
+            .header("Cookie", &cookie)
+            // Cursor's dashboard endpoints reject cross-origin POSTs without a
+            // matching Origin/Referer (CSRF guard).
+            .header("Origin", "https://cursor.com")
+            .header("Referer", "https://cursor.com/dashboard")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("Cursor usage request failed: {}", e))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("read Cursor usage response: {}", e))?;
+        if status.as_u16() == 401 {
+            return Err("Cursor session expired. Open Cursor and sign in again.".to_string());
+        }
+        if !status.is_success() {
+            return Err(format!("Cursor usage API returned {}.", status.as_u16()));
+        }
+        let parsed: FilteredUsageResponse = serde_json::from_str(&text)
+            .map_err(|e| format!("decode Cursor usage response: {}", e))?;
+        let batch = parsed.events.unwrap_or_default();
+        let total = parsed.total.unwrap_or(0);
+        if batch.is_empty() {
+            break;
+        }
+        for raw in batch {
+            let Some(ts) = raw
+                .timestamp
+                .as_deref()
+                .and_then(|s| s.trim().parse::<i64>().ok())
+            else {
+                continue;
+            };
+            let tu = raw.token_usage;
+            events.push(CachedCursorEvent {
+                timestamp_ms: ts,
+                model: raw.model.unwrap_or_else(|| "cursor".to_string()),
+                input_tokens: tu.as_ref().and_then(|t| t.input_tokens).unwrap_or(0).max(0),
+                output_tokens: tu.as_ref().and_then(|t| t.output_tokens).unwrap_or(0).max(0),
+                cache_read_tokens: tu
+                    .as_ref()
+                    .and_then(|t| t.cache_read_tokens)
+                    .unwrap_or(0)
+                    .max(0),
+                cost: tu.as_ref().and_then(|t| t.total_cents).unwrap_or(0.0).max(0.0) / 100.0,
+            });
+        }
+        if total > 0 && (events.len() as i64) >= total {
+            break;
+        }
+        page += 1;
+        if page > 1000 {
+            break; // safety valve against an endless paginate loop
+        }
+    }
+
+    write_cache(&CursorCache {
+        fetched_at_ms: now_ms(),
+        events,
+    })
+}
+
+/// Remove the JSON cache this module owns. Best-effort and intentionally leaves
+/// any legacy `usage*.csv` cache (which predates Tokcat and we didn't create)
+/// untouched.
+pub fn clear_cache() {
+    if let Ok(path) = cache_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn write_cache(cache: &CursorCache) -> Result<(), String> {
+    let path = cache_path()?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| format!("create cursor cache dir: {}", e))?;
+    }
+    let json = serde_json::to_string(cache).map_err(|e| format!("serialize cursor cache: {}", e))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json).map_err(|e| format!("write cursor cache: {}", e))?;
+    std::fs::rename(&tmp, &path).map_err(|e| format!("commit cursor cache: {}", e))?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod animation;
 mod agent_usage;
+mod cursor_usage;
 #[cfg(target_os = "macos")]
 mod native_tray;
 mod state;
@@ -85,6 +86,13 @@ async fn refresh_graph(
     let state_inner: &Arc<AppState> = &*state;
     let _guard = RefreshGuard { state: state_inner };
 
+    // Opt-in: refresh the Cursor usage cache before reading the graph so the
+    // rebuild below sees the latest events. Best-effort — a fetch failure
+    // (Cursor signed out, offline) must not block the local graph refresh.
+    if state.is_cursor_usage_enabled() {
+        let _ = cursor_usage::refresh_cache().await;
+    }
+
     let year_clone = year.clone();
     let data = async_runtime::spawn_blocking(move || usage_graph::run(&year_clone))
         .await
@@ -150,6 +158,26 @@ fn set_animation_style(style: String, state: tauri::State<'_, Arc<AppState>>) {
         _ => 0u32,
     };
     state.set_animation_style(code);
+}
+
+/// Toggle the opt-in Cursor usage fetch. On enable we fetch once immediately so
+/// the user sees data without waiting for the next refresh tick; the returned
+/// error (if any) lets the frontend surface why it couldn't (Cursor signed out,
+/// offline). The frontend triggers a graph refresh after this resolves.
+#[tauri::command]
+async fn set_cursor_usage_enabled(
+    enabled: bool,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<(), String> {
+    state.set_cursor_usage_enabled(enabled);
+    if enabled {
+        cursor_usage::refresh_cache().await?;
+    } else {
+        // Opting out hides Cursor: drop the cache so parse_cursor stops
+        // surfacing stale data on the next graph rebuild.
+        cursor_usage::clear_cache();
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -220,6 +248,11 @@ fn spawn_refresh_loop(app: tauri::AppHandle, state: Arc<AppState>) {
     async_runtime::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_secs(REFRESH_SECS)).await;
+            // Opt-in: pull fresh Cursor usage once per cycle (covers every year)
+            // before the per-year graph rebuilds below. Best-effort.
+            if state.is_cursor_usage_enabled() {
+                let _ = cursor_usage::refresh_cache().await;
+            }
             let years = state.known_years();
             for year in years {
                 let s = state.clone();
@@ -340,6 +373,7 @@ pub fn run() {
             pop_dialog_shield,
             set_animate_tray,
             set_animation_style,
+            set_cursor_usage_enabled,
             get_usage_trace,
             get_tokens_per_min,
             get_agent_usage,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -25,6 +25,10 @@ pub struct AppState {
     // Set while a refresh fetch is in flight. The bounce loop reads this to
     // start the up/down animation on the tray cat.
     refreshing: AtomicBool,
+    // Opt-in: when true the refresh path fetches Cursor usage from cursor.com
+    // (the only client without a local token/cost ledger). Off by default to
+    // keep Tokcat local-first unless the user explicitly enables it.
+    cursor_usage_enabled: AtomicBool,
     tailer: Arc<UsageTailer>,
 }
 
@@ -36,6 +40,7 @@ impl AppState {
             animation_style: AtomicU32::new(2),
             suppress_blur_hide: AtomicU32::new(0),
             refreshing: AtomicBool::new(false),
+            cursor_usage_enabled: AtomicBool::new(false),
             tailer: Arc::new(UsageTailer::new()),
         })
     }
@@ -130,6 +135,14 @@ impl AppState {
 
     pub fn is_animate_enabled(&self) -> bool {
         self.animate_enabled.load(Ordering::SeqCst)
+    }
+
+    pub fn set_cursor_usage_enabled(&self, enabled: bool) {
+        self.cursor_usage_enabled.store(enabled, Ordering::SeqCst);
+    }
+
+    pub fn is_cursor_usage_enabled(&self) -> bool {
+        self.cursor_usage_enabled.load(Ordering::SeqCst)
     }
 
     pub fn known_years(&self) -> Vec<String> {

--- a/src-tauri/src/usage_graph.rs
+++ b/src-tauri/src/usage_graph.rs
@@ -793,9 +793,20 @@ fn parse_cursor() -> Vec<UsageMessage> {
     let Some(home) = home_dir() else {
         return Vec::new();
     };
-    // Cursor's usage source is still the local compatibility cache produced by
-    // older Tokcat/tokscale setups. Reading it avoids dropping historical data.
     let root = home.join(".config").join("tokscale").join("cursor-cache");
+    // Preferred source: the JSON cache written by the opt-in cursor_usage
+    // fetcher (per-event tokens + cost from cursor.com). When present it
+    // supersedes the legacy CSV — same data, richer — so we don't read both
+    // and double-count.
+    let json_cache = root.join("tokcat-events.json");
+    if json_cache.is_file() {
+        let msgs = parse_cursor_cache_json(&json_cache);
+        if !msgs.is_empty() {
+            return msgs;
+        }
+    }
+    // Fallback: the local compatibility CSV cache produced by older
+    // Tokcat/tokscale setups. Reading it avoids dropping historical data.
     collect_files(&root, |p| {
         p.file_name().and_then(|s| s.to_str()).is_some_and(|name| {
             name == "usage.csv" || (name.starts_with("usage.") && name.ends_with(".csv"))
@@ -804,6 +815,54 @@ fn parse_cursor() -> Vec<UsageMessage> {
     .into_iter()
     .flat_map(|p| parse_cursor_file(&p))
     .collect()
+}
+
+fn parse_cursor_cache_json(path: &Path) -> Vec<UsageMessage> {
+    let Ok(content) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    #[derive(serde::Deserialize)]
+    struct Cache {
+        events: Vec<Event>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Event {
+        timestamp_ms: i64,
+        model: String,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cost: f64,
+    }
+    let Ok(cache) = serde_json::from_str::<Cache>(&content) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for e in cache.events {
+        if e.timestamp_ms <= 0 {
+            continue;
+        }
+        let mut msg = UsageMessage::new(
+            "cursor",
+            e.model.as_str(),
+            infer_provider(&e.model),
+            e.timestamp_ms,
+            TokenBreakdown {
+                input: e.input_tokens.max(0),
+                output: e.output_tokens.max(0),
+                cache_read: e.cache_read_tokens.max(0),
+                cache_write: 0,
+                reasoning: 0,
+            },
+            e.cost.max(0.0),
+        );
+        msg.dedup_key = Some(format!(
+            "cursor:{}:{}:{}",
+            e.timestamp_ms, e.input_tokens, e.output_tokens
+        ));
+        out.push(msg);
+    }
+    out
 }
 
 fn parse_cursor_file(path: &Path) -> Vec<UsageMessage> {
@@ -2272,6 +2331,38 @@ mod tests {
             "claude-sonnet-4-5",
             "anthropic",
             Price::new(3.0, 15.0, 0.3, 3.75).above_200k(6.0, 22.5, 0.6, 7.5),
+        );
+    }
+
+    #[test]
+    fn cursor_json_cache_maps_events_to_usage_messages() {
+        let dir = std::env::temp_dir().join(format!("tokcat-cursor-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tokcat-events.json");
+        // Shape mirrors a real get-filtered-usage-events row flattened by
+        // cursor_usage::CachedCursorEvent.
+        let json = r#"{"fetched_at_ms":1781757600000,"events":[
+            {"timestamp_ms":1781757574236,"model":"composer-2.5","input_tokens":555,"output_tokens":599,"cache_read_tokens":3988,"cost":0.0025726},
+            {"timestamp_ms":0,"model":"bad","input_tokens":1,"output_tokens":1,"cache_read_tokens":0,"cost":0.0}
+        ]}"#;
+        std::fs::write(&path, json).unwrap();
+
+        let msgs = parse_cursor_cache_json(&path);
+        std::fs::remove_dir_all(&dir).ok();
+
+        // The zero-timestamp row is dropped; the valid one maps through.
+        assert_eq!(msgs.len(), 1);
+        let m = &msgs[0];
+        assert_eq!(m.client, "cursor");
+        assert_eq!(m.model_id, normalize_model_id("composer-2.5"));
+        assert_eq!(m.tokens.input, 555);
+        assert_eq!(m.tokens.output, 599);
+        assert_eq!(m.tokens.cache_read, 3988);
+        assert_eq!(m.tokens.cache_write, 0);
+        assert!((m.cost - 0.0025726).abs() < 1e-9);
+        assert_eq!(
+            m.dedup_key.as_deref(),
+            Some("cursor:1781757574236:555:599")
         );
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,6 +408,29 @@ export default function App() {
     })()
   }, [settings.animationStyle])
 
+  // Push the Cursor-usage opt-in to the backend. On enable the backend fetches
+  // once; refresh the graph so the new data shows immediately. If the fetch
+  // fails (Cursor signed out / offline), revert the toggle so it reflects what
+  // actually happened.
+  useEffect(() => {
+    if (!isTauri()) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core')
+        await invoke('set_cursor_usage_enabled', { enabled: settings.cursorUsage })
+        if (!cancelled && settings.cursorUsage) setRefreshTick(t => t + 1)
+      } catch (e) {
+        if (cancelled) return
+        console.error('Cursor usage fetch failed:', e)
+        if (settings.cursorUsage) setSettings(s => ({ ...s, cursorUsage: false }))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [settings.cursorUsage])
+
   // Resize the native window to fit the current content height. The trace
   // card's row count changes as buckets come and go; without this the
   // window either crops the trace or shows trailing whitespace.

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -231,6 +231,21 @@ export function SettingsPanel({ open, onClose, settings, onChange }: Props) {
             </div>
           </section>
 
+          {tauri && (
+            <section className="settings-section">
+              <div className="settings-label">Cursor usage</div>
+              <div className="settings-group">
+                <div className="settings-row">
+                  <span className="settings-row-label">Fetch from cursor.com</span>
+                  <SwitchToggle
+                    checked={settings.cursorUsage}
+                    onChange={next => onChange({ ...settings, cursorUsage: next })}
+                  />
+                </div>
+              </div>
+            </section>
+          )}
+
           <section className="settings-section">
             <div className="settings-label">About</div>
             <div className="settings-group">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -18,6 +18,10 @@ export interface Settings {
   // When true, the Live trace card splits rows by (client, agent, model);
   // otherwise rows collapse to one per client.
   detailedTrace: boolean
+  // Opt-in: fetch Cursor usage from cursor.com. Off by default because, unlike
+  // every other client, Cursor has no local token/cost ledger — enabling it
+  // makes a network request authenticated with your Cursor session.
+  cursorUsage: boolean
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -26,6 +30,7 @@ export const DEFAULT_SETTINGS: Settings = {
   animateTray: true,
   animationStyle: 'cat',
   detailedTrace: false,
+  cursorUsage: false,
 }
 
 export const ANIMATION_STYLE_LABELS: Record<AnimationStyle, string> = {


### PR DESCRIPTION
Fixes #22.

Two independent issues the reporter hit on a fresh Homebrew install:

## 1. Codex shown though not installed
The live agent-limits panel hardcoded `[Codex, Claude]` and rendered a tile for each regardless of setup — with no credentials it fell back to an **error** tile instead of hiding, so Codex looked "detected" when it wasn't.

**Fix:** `agent_usage::run()` now gates each agent on a config-presence check and omits the tile when the agent isn't set up (`~/.codex/auth.json` absent; no Claude env / Keychain / credentials file). An agent that *is* configured but failing (expired token, offline) still shows its error so the user knows to re-authenticate.

## 2. Cursor not detected
Cursor — uniquely among Tokcat's clients — keeps **no local token/cost ledger**; its usage lives server-side. The old code only read a legacy `cursor-cache/usage*.csv` that older tokscale setups generated, which a fresh install never has.

**Fix (opt-in):** a new `cursor_usage` module fetches per-event usage (tokens + cost) from Cursor's dashboard API and writes a JSON cache that the existing synchronous `parse_cursor` reads — the graph pipeline stays local + sync.
- Live session token read from Cursor's `state.vscdb` (`cursorAuth/accessToken`); the Keychain copy is only written at login and goes stale.
- `POST /api/dashboard/get-filtered-usage-events` (paginated, with the Origin/Referer CSRF headers), mapped to per-message token/cost.
- Gated behind `AppState.cursor_usage_enabled` + a **Settings → Cursor usage → Fetch from cursor.com** toggle, **off by default** to preserve Tokcat's local-first guarantee. Enabling fetches immediately and refreshes; disabling clears the cache.

The Cursor API is undocumented, so it may need maintenance if Cursor changes it; the opt-in keeps the default behavior fully local.

## Verification
- `cargo test` — 22 passed / 0 failed (incl. a new `parse_cursor_cache_json` mapping test).
- Live end-to-end against the real API: fetched **528 events** ($122.09, 223.6M tokens); `usage_graph::run` then surfaced Cursor contributions matching the cache exactly per year (2026: 3 days / 269,557 tokens; 2025: 59 days / 223.4M tokens).
- Frontend `tsc --noEmit` clean + `vite build` OK.

> Note: GUI flow (toggle → graph renders Cursor) verified at the data-payload level, not visually.