### PR TITLE
Release Tokcat 0.1.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4608,7 +4608,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.32"
+version = "0.1.33"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Release 0.1.33

버전 범프 (`0.1.32` → `0.1.33`) — `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` + `cargo check`로 `Cargo.lock` 갱신.

### 이 릴리스에 포함되는 변경
- **#24 — Show popover when Tokcat is re-launched while running**: 실행 중인 Tokcat을 다시 열면(Finder/Launchpad/Spotlight/`open`/Dock, 또는 바이너리 직접 실행) 팝오버가 뜨도록 수정. 작은 화면/노치 맥에서 메뉴바 아이콘이 가려져도 앱을 다시 열어 접근할 수 있는 탈출구를 제공. `RunEvent::Reopen` 처리 + `tauri-plugin-single-instance` 추가.

### 머지 후 릴리스 절차 (AGENTS.md)
이 PR을 머지한 뒤 `v0.1.33` 태그를 푸시하면 `.github/workflows/release.yml`가 DMG 빌드 · GitHub Release 발행 · `latest.json` 생성 · Homebrew tap 범프까지 자동 수행합니다.

```sh
git tag -a v0.1.33 -m "Tokcat 0.1.33"
git push origin v0.1.33
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)