### PR TITLE
Fix launch crash: dispatch single-instance popover to the main thread

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -351,8 +351,18 @@ pub fn run() {
         // (e.g. running the binary directly, or `open -n`), this fires in the
         // already-running instance instead of starting a duplicate tray — we
         // surface the popover, mirroring the RunEvent::Reopen path below.
+        //
+        // The plugin runs this callback on its socket-listener task (a
+        // tokio-rt-worker thread), so it must NOT touch AppKit directly:
+        // show_popover orders/focuses the NSWindow, which is main-thread-only
+        // and traps ("Must only be used from the main thread") otherwise.
+        // Hop to the main thread first — unlike the RunEvent::Reopen path,
+        // which already runs on the main event loop.
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
-            tray::show_popover(app);
+            let handle = app.clone();
+            let _ = app.run_on_main_thread(move || {
+                tray::show_popover(&handle);
+            });
         }))
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,


### PR DESCRIPTION
## Summary

Fixes #28 — Tokcat crashes with `EXC_BREAKPOINT` / *"Must only be used from the main thread"* on `tokio-rt-worker`, in `_doOrderWindow`.

## Root cause

The `tauri-plugin-single-instance` callback registered in `lib.rs` runs on the plugin's socket-listener task, which the plugin spawns via `tauri::async_runtime::spawn(...)` — i.e. a **`tokio-rt-worker`** thread, not the main thread ([plugin source](https://docs.rs/crate/tauri-plugin-single-instance/2.4.2), `platform_impl/macos.rs` → `listen_for_other_instances`).

That callback called `tray::show_popover(app)` directly, which drives AppKit `NSWindow` ordering/focus APIs (`setLevel`, `setCollectionBehavior`, `orderFrontRegardless`, `set_focus`). Those are **main-thread-only**; invoking them off-main traps immediately — matching the reported crash thread and the `_doOrderWindow` frames exactly.

Regression from `3883b1e` ("Show popover when Tokcat is re-launched while running").

### Why it looks like "crashes on every launch"

The reporter is on a **notched MacBook Pro (Mac16,1)** — the exact scenario `3883b1e` targeted. The menu bar icon is hidden behind the notch, so:

1. First launch → becomes the primary instance, works, but its tray icon is invisible behind the notch.
2. User re-launches to find it → the second process hands its argv to the primary over the socket and `exit(0)`s (the brief Dock icon they saw).
3. The **primary's** listener (tokio worker) fires `show_popover` → primary crashes in `_doOrderWindow`.
4. Icon still not visible → user re-launches → same crash. Hence "3 times in a row, identical stack trace."

The `RunEvent::Reopen` path is unaffected: it already runs on the main event loop.

## Fix

Hop to the main thread with `run_on_main_thread(...)` before touching AppKit — the same pattern already used by `native_tray::set_y_offset`:

```rust
.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
    let handle = app.clone();
    let _ = app.run_on_main_thread(move || {
        tray::show_popover(&handle);
    });
}))
```

## Testing

- `cargo check` passes (only pre-existing `native_tray` warnings, unrelated).
- Manual verification of the second-instance path (`open -n` / run the binary directly while a primary is running) is worth a sanity check before release, since the trap only fires with a live primary.