### PR TITLE
Release Tokcat 0.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4608,7 +4608,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
Version bump 0.1.33 → 0.1.34 across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` (all four must match or the Release workflow's `meta` job fails).

## What ships in 0.1.34

- **Add Grok Build usage tracking** — history, live tail, and OAuth quota (#27)
- **Fix launch/relaunch crash** — showing the popover from the single-instance handler invoked `NSWindow` ordering on a `tokio-rt-worker` thread, tripping macOS's main-thread requirement (`EXC_BREAKPOINT` / "Must only be used from the main thread"). Now dispatched to the main thread. Fixes #28 (#29)

## Release mechanics

Merging this bumps main. Pushing an annotated `v0.1.34` tag on the merge commit triggers `.github/workflows/release.yml`, which builds + signs both arches on GitHub-hosted runners, publishes the GitHub Release, and bumps the Homebrew cask. **No local/Mac Mini build needed.**

Draft annotated-tag message (CI uses it verbatim as the release notes):

```
Tokcat 0.1.34

- Add Grok Build usage tracking: history, live tail, and OAuth quota.
- Fix a crash when re-opening Tokcat while it was already running — the
  popover was shown from a background thread, tripping macOS's
  main-thread requirement for window ordering. Re-launch now reliably
  shows the popover instead of crashing the running instance.
```