### PR TITLE
Release Tokcat 0.1.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4608,7 +4608,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -375,7 +375,11 @@ export default function App() {
   // Push tray title from the all-agent overview, regardless of the visible tab.
   useEffect(() => {
     if (!isTauri()) return
-    const title = computeTrayTitle(settings.trayMode, overviewStats, tokensPerMin)
+    const title = computeTrayTitle(settings.trayMode, overviewStats, tokensPerMin, agentUsage.payload, {
+      provider: settings.planProvider,
+      window: settings.planWindow,
+      displayMode: settings.planDisplayMode,
+    })
     ;(async () => {
       try {
         const { invoke } = await import('@tauri-apps/api/core')
@@ -384,7 +388,15 @@ export default function App() {
         // ignore
       }
     })()
-  }, [overviewStats, settings.trayMode, tokensPerMin])
+  }, [
+    overviewStats,
+    settings.trayMode,
+    tokensPerMin,
+    agentUsage.payload,
+    settings.planProvider,
+    settings.planWindow,
+    settings.planDisplayMode,
+  ])
 
   // Push animateTray flag to backend whenever it changes (Tauri only).
   useEffect(() => {
@@ -556,6 +568,7 @@ export default function App() {
         onClose={() => setSettingsOpen(false)}
         settings={settings}
         onChange={setSettings}
+        agentUsage={agentUsage.payload}
       />
       {aboutOpen && (
         <>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,10 +2,14 @@ import React, { useEffect, useState } from 'react'
 import {
   AnimationStyle,
   ANIMATION_STYLE_LABELS,
+  PlanDisplayMode,
+  PlanProvider,
+  PLAN_PROVIDER_LABELS,
   Settings,
   TrayMode,
   TRAY_MODE_LABELS,
 } from '../lib/settings'
+import type { AgentUsagePayload } from '../lib/agentUsage'
 import { isTauri } from '../lib/runtime'
 import { checkForUpdatesInteractive } from '../lib/updater'
 
@@ -14,6 +18,7 @@ interface Props {
   onClose: () => void
   settings: Settings
   onChange: (s: Settings) => void
+  agentUsage?: AgentUsagePayload | null
 }
 
 function SwitchToggle({
@@ -47,7 +52,19 @@ function CheckIcon() {
   )
 }
 
-export function SettingsPanel({ open, onClose, settings, onChange }: Props) {
+const PLAN_PROVIDER_OPTIONS: { id: PlanProvider; label: string }[] = [
+  { id: 'auto', label: 'Auto — most constrained' },
+  { id: 'claude', label: PLAN_PROVIDER_LABELS.claude },
+  { id: 'codex', label: PLAN_PROVIDER_LABELS.codex },
+  { id: 'grok', label: PLAN_PROVIDER_LABELS.grok },
+]
+
+const PLAN_DISPLAY_OPTIONS: { id: PlanDisplayMode; label: string }[] = [
+  { id: 'used', label: '% used' },
+  { id: 'left', label: '% left' },
+]
+
+export function SettingsPanel({ open, onClose, settings, onChange, agentUsage }: Props) {
   const [autostartBusy, setAutostartBusy] = useState(false)
   const [version, setVersion] = useState<string>('')
   const [updateBusy, setUpdateBusy] = useState(false)
@@ -135,8 +152,29 @@ export function SettingsPanel({ open, onClose, settings, onChange }: Props) {
     'total_tokens',
     'total_cost',
     'tokens_per_min',
+    'plan_percent',
     'hidden',
   ]
+
+  // Snapshots for plan-capable providers that actually have windows right now.
+  // Drives which providers are selectable and which windows can be pinned.
+  const planSnapshots = new Map(
+    (agentUsage?.agents ?? []).filter(a => a.windows.length > 0).map(a => [a.clientId, a]),
+  )
+  const windowsFor = (provider: PlanProvider): string[] =>
+    provider === 'auto' ? [] : planSnapshots.get(provider)?.windows.map(w => w.label) ?? []
+
+  const selectPlanProvider = (provider: PlanProvider) => {
+    if (provider === 'auto') {
+      onChange({ ...settings, planProvider: provider })
+      return
+    }
+    // Pin a valid window for the chosen provider: keep the current one if it
+    // still exists, else default to the provider's first window.
+    const wins = windowsFor(provider)
+    const planWindow = wins.includes(settings.planWindow) ? settings.planWindow : wins[0] ?? settings.planWindow
+    onChange({ ...settings, planProvider: provider, planWindow })
+  }
 
   return (
     <>
@@ -170,6 +208,81 @@ export function SettingsPanel({ open, onClose, settings, onChange }: Props) {
               })}
             </div>
           </section>
+
+          {settings.trayMode === 'plan_percent' && (
+            <section className="settings-section">
+              <div className="settings-label">Plan source</div>
+              <div className="settings-group">
+                {PLAN_PROVIDER_OPTIONS.map(opt => {
+                  const active = settings.planProvider === opt.id
+                  // Specific providers are only selectable once their quota has
+                  // loaded; Auto is always available.
+                  const available = opt.id === 'auto' || planSnapshots.has(opt.id)
+                  return (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      className={`settings-row settings-row-radio${active ? ' is-active' : ''}`}
+                      onClick={() => available && selectPlanProvider(opt.id)}
+                      disabled={!available}
+                      aria-pressed={active}
+                    >
+                      <span className="settings-row-label">
+                        {opt.label}
+                        {!available && <span className="settings-row-meta"> · no data yet</span>}
+                      </span>
+                      <span className="settings-row-check">{active && <CheckIcon />}</span>
+                    </button>
+                  )
+                })}
+              </div>
+
+              {settings.planProvider !== 'auto' && (
+                <div className="settings-group">
+                  {windowsFor(settings.planProvider).length === 0 ? (
+                    <div className="settings-row">
+                      <span className="settings-row-label settings-row-meta">No windows available yet</span>
+                    </div>
+                  ) : (
+                    windowsFor(settings.planProvider).map(label => {
+                      const active = settings.planWindow === label
+                      return (
+                        <button
+                          key={label}
+                          type="button"
+                          className={`settings-row settings-row-radio${active ? ' is-active' : ''}`}
+                          onClick={() => onChange({ ...settings, planWindow: label })}
+                          aria-pressed={active}
+                        >
+                          <span className="settings-row-label">{label}</span>
+                          <span className="settings-row-check">{active && <CheckIcon />}</span>
+                        </button>
+                      )
+                    })
+                  )}
+                </div>
+              )}
+
+              <div className="settings-label">Display</div>
+              <div className="settings-group">
+                {PLAN_DISPLAY_OPTIONS.map(opt => {
+                  const active = settings.planDisplayMode === opt.id
+                  return (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      className={`settings-row settings-row-radio${active ? ' is-active' : ''}`}
+                      onClick={() => onChange({ ...settings, planDisplayMode: opt.id })}
+                      aria-pressed={active}
+                    >
+                      <span className="settings-row-label">{opt.label}</span>
+                      <span className="settings-row-check">{active && <CheckIcon />}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </section>
+          )}
 
           {tauri && (
             <section className="settings-section">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,5 @@
 import type { Stats } from './types'
+import type { AgentUsagePayload } from './agentUsage'
 import { humanizeTokens, formatCost, isoDate } from './format'
 
 export type TrayMode =
@@ -7,8 +8,24 @@ export type TrayMode =
   | 'total_tokens'
   | 'total_cost'
   | 'tokens_per_min'
+  | 'plan_percent'
   | 'hidden'
 export type AnimationStyle = 'cat' | 'parrot'
+
+// Providers that expose an OAuth plan/quota cap, so a "% used / % left" is
+// meaningful. Log-parsed clients (cursor, gemini, copilot, …) only report
+// cumulative tokens and are intentionally excluded here.
+export type PlanProvider = 'auto' | 'claude' | 'codex' | 'grok'
+export type PlanDisplayMode = 'used' | 'left'
+
+// Short labels shown in the (text-only) menubar title. The status item can't
+// render SVGs, so we prefix the percentage with a compact provider name.
+export const PLAN_PROVIDER_LABELS: Record<Exclude<PlanProvider, 'auto'>, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  grok: 'Grok',
+}
+export const PLAN_CAPABLE_PROVIDERS = ['claude', 'codex', 'grok'] as const
 
 export interface Settings {
   trayMode: TrayMode
@@ -22,6 +39,13 @@ export interface Settings {
   // every other client, Cursor has no local token/cost ledger — enabling it
   // makes a network request authenticated with your Cursor session.
   cursorUsage: boolean
+  // Menubar plan-percentage display (only used when trayMode === 'plan_percent').
+  // planProvider === 'auto' shows whichever window is closest to its cap.
+  planProvider: PlanProvider
+  // Which usage window to pin (e.g. 'Session' / 'Weekly'); ignored when auto.
+  planWindow: string
+  // Show percentage consumed ('used') or remaining ('left').
+  planDisplayMode: PlanDisplayMode
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -31,6 +55,9 @@ export const DEFAULT_SETTINGS: Settings = {
   animationStyle: 'cat',
   detailedTrace: false,
   cursorUsage: false,
+  planProvider: 'auto',
+  planWindow: 'Session',
+  planDisplayMode: 'used',
 }
 
 export const ANIMATION_STYLE_LABELS: Record<AnimationStyle, string> = {
@@ -68,15 +95,84 @@ export const TRAY_MODE_LABELS: Record<TrayMode, string> = {
   total_tokens: 'Total tokens (1.5B)',
   total_cost: 'Total cost ($889)',
   tokens_per_min: 'Tokens / min (12.4K/m)',
+  plan_percent: 'Plan usage (42%)',
   hidden: 'Icon only',
+}
+
+export interface PlanSelection {
+  provider: PlanProvider
+  window: string
+  displayMode: PlanDisplayMode
+}
+
+export const DEFAULT_PLAN_SELECTION: PlanSelection = {
+  provider: 'auto',
+  window: 'Session',
+  displayMode: 'used',
+}
+
+function clampPercent(value: number): number {
+  return Math.round(Math.min(100, Math.max(0, value)))
+}
+
+// Resolve which provider/window the menubar should show. In 'auto' mode we pick
+// the window closest to its cap (highest usedPercent) across all plan-capable
+// providers; otherwise we honor the pinned provider + window, falling back to
+// that provider's first window if the pinned label is gone. Returns null when
+// no plan-capable provider has any windows yet (loading / not signed in).
+function pickPlanWindow(
+  agentUsage: AgentUsagePayload | null,
+  provider: PlanProvider,
+  windowLabel: string,
+): { providerId: string; usedPercent: number; remainingPercent: number } | null {
+  const candidates = (agentUsage?.agents ?? []).filter(
+    a => (PLAN_CAPABLE_PROVIDERS as readonly string[]).includes(a.clientId) && a.windows.length > 0,
+  )
+  if (candidates.length === 0) return null
+
+  if (provider === 'auto') {
+    let best: { providerId: string; usedPercent: number; remainingPercent: number } | null = null
+    for (const agent of candidates) {
+      for (const w of agent.windows) {
+        if (!best || w.usedPercent > best.usedPercent) {
+          best = { providerId: agent.clientId, usedPercent: w.usedPercent, remainingPercent: w.remainingPercent }
+        }
+      }
+    }
+    return best
+  }
+
+  const agent = candidates.find(a => a.clientId === provider)
+  if (!agent) return null
+  const w = agent.windows.find(x => x.label === windowLabel) ?? agent.windows[0]
+  return { providerId: agent.clientId, usedPercent: w.usedPercent, remainingPercent: w.remainingPercent }
+}
+
+function computePlanTitle(agentUsage: AgentUsagePayload | null, plan: PlanSelection): string {
+  const picked = pickPlanWindow(agentUsage, plan.provider, plan.window)
+  if (!picked) return '—'
+  const label = PLAN_PROVIDER_LABELS[picked.providerId as Exclude<PlanProvider, 'auto'>] ?? picked.providerId
+  const used = clampPercent(picked.usedPercent)
+  // Flag windows at/over 80% consumed so the menubar warns before you run out.
+  const warn = used >= 80 ? '⚠ ' : ''
+  if (plan.displayMode === 'left') {
+    return `${warn}${label} ${clampPercent(picked.remainingPercent)}% left`
+  }
+  return `${warn}${label} ${used}%`
 }
 
 export function computeTrayTitle(
   mode: TrayMode,
   stats: Stats | null,
   tokensPerMin: number | null = null,
+  agentUsage: AgentUsagePayload | null = null,
+  plan: PlanSelection = DEFAULT_PLAN_SELECTION,
 ): string {
-  if (mode === 'hidden' || !stats) return ''
+  if (mode === 'hidden') return ''
+  // Plan percentage comes from OAuth quota, not the local token stats, so it is
+  // resolved before the `!stats` guard that the token/cost modes depend on.
+  if (mode === 'plan_percent') return computePlanTitle(agentUsage, plan)
+  if (!stats) return ''
   const today = isoDate(new Date())
   const todayEntry = stats.perDayMap.get(today)
   switch (mode) {


### PR DESCRIPTION
## Summary
Adds a **Plan usage** option to the menubar (closes #26).

- Shows **Claude / Codex / Grok** plan usage as a percentage in the menubar title
- Two display modes: **% used** (`Claude 42%`) and **% left** (`Claude 58% left`)
- **Auto** mode surfaces whichever window is closest to its cap across all plan-capable providers; a `⚠` prefix appears at ≥80% used
- Providers without a plan cap (Cursor and log-parsed clients) are intentionally excluded
- New Settings sub-panel under *Menubar title* to pick provider / window / used-vs-left

## Implementation
- `src/lib/settings.ts` — `plan_percent` TrayMode, plan settings + defaults, provider/window resolution, `computeTrayTitle` plumbing
- `src/App.tsx` — pass `agentUsage.payload` + plan settings into the tray-title effect; feed `agentUsage` to SettingsPanel
- `src/components/SettingsPanel.tsx` — plan-source / window / display controls
- No Rust changes — `update_tray_title` already accepts an arbitrary string; quota data already flows via `get_agent_usage`

## Verification
- `tsc --noEmit` clean, `vite build` succeeds
- Pure-function logic unit-checked (11/11): auto/most-constrained selection, used/left formatting, ≥80% warn, window fallback, no-data/em-dash, provider exclusion

Version bumped to **0.1.35** across package.json / Cargo.toml / Cargo.lock / tauri.conf.json.