### PR TITLE
Release Tokcat 0.1.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokcat",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4608,7 +4608,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokcat"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokcat"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 description = "Native macOS menubar dashboard for local AI token usage"
 authors = ["handlecusion"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Tokcat",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "identifier": "com.handlecusion.tokcat",
   "build": {
     "beforeDevCommand": "npm run dev:vite",


### PR DESCRIPTION
## Summary

Cut the 0.1.38 patch release. Bumps the version to `0.1.38` across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.lock` so the tagged build passes the release version check.

## Changes since 0.1.37

- **Codex Business plan usage** — parse `spend_control.individual_limit` when `rate_limit` is null and surface it as a "Monthly spend" window (#34)
- **Claude OAuth refresh** — send the refresh request as JSON (the token endpoint rejects form-urlencoded), matching the canonical Claude Code flow (#34)

## Release

Merging this, then pushing the `v0.1.38` tag triggers the release workflow (signed arm64/x64 DMGs, GitHub Release, `latest.json` auto-updater manifest, Homebrew tap bump).