### PR TITLE
Fix stray accent outline on 2D daily bars

### DIFF
--- a/src/components/UsageBarGraph2D.tsx
+++ b/src/components/UsageBarGraph2D.tsx
@@ -239,20 +239,33 @@ export function UsageBarGraph2D({
                   <rect x={x} y={height - bottom - 2} width={barWidth} height={2} rx={1} className="bar2d-empty" />
                 )}
                 {(bar.totalTokens > 0 || bar.totalCost > 0) && (
-                  <rect
-                    className="bar2d-hit"
-                    x={x}
-                    y={top}
-                    width={barWidth}
-                    height={chartHeight}
-                    tabIndex={0}
-                    role="img"
-                    aria-label={`${formatMonthDay(bar.date)}, ${exactTokens(bar.totalTokens)} tokens, ${formatCost(bar.totalCost)}`}
-                    onMouseEnter={() => showTooltip(bar, index)}
-                    onMouseMove={() => showTooltip(bar, index)}
-                    onFocus={() => showTooltip(bar, index)}
-                    onBlur={() => setHover(null)}
-                  />
+                  <>
+                    <rect
+                      className="bar2d-hit"
+                      x={x}
+                      y={top}
+                      width={barWidth}
+                      height={chartHeight}
+                      tabIndex={0}
+                      role="img"
+                      aria-label={`${formatMonthDay(bar.date)}, ${exactTokens(bar.totalTokens)} tokens, ${formatCost(bar.totalCost)}`}
+                      onMouseEnter={() => showTooltip(bar, index)}
+                      onMouseMove={() => showTooltip(bar, index)}
+                      onFocus={() => showTooltip(bar, index)}
+                      onBlur={() => setHover(null)}
+                      // WebKit focuses tabindex elements on click, leaving the keyboard
+                      // focus ring stuck on the bar after mouse interaction.
+                      onMouseDown={event => event.preventDefault()}
+                    />
+                    <rect
+                      className="bar2d-focus"
+                      x={x}
+                      y={height - bottom - Math.max(totalHeight, 4)}
+                      width={barWidth}
+                      height={Math.max(totalHeight, 4)}
+                      rx={2}
+                    />
+                  </>
                 )}
               </g>
             )

--- a/src/styles.css
+++ b/src/styles.css
@@ -749,7 +749,12 @@ html, body, #root {
   pointer-events: all;
   outline: none;
 }
-.bar2d-hit:focus-visible {
+.bar2d-focus {
+  fill: none;
+  stroke: none;
+  pointer-events: none;
+}
+.bar2d-hit:focus-visible + .bar2d-focus {
   stroke: var(--blue);
   stroke-width: 1.5;
 }


### PR DESCRIPTION
## Problem

On the 2D daily usage chart, an accent-colored (orange, with the Orange theme) frame could appear behind a bar — e.g. the Jul 17 bar showed orange bleeding out around the gray Codex segment:

The cause: each bar has an invisible full-column `.bar2d-hit` rect (`tabIndex=0`) for hover/keyboard access. WebKit focuses tabindex elements on mouse down, and the `:focus-visible` stroke (`var(--blue)`, overridden to the theme accent) then stays painted as a chart-height outline until something else takes focus.

## Fix

- `onMouseDown` → `preventDefault()` on the hit rect, so mouse interaction never leaves a focus ring (tooltips are hover-driven and unaffected).
- The keyboard focus ring now draws on a dedicated `.bar2d-focus` rect that hugs the actual bar (`.bar2d-hit:focus-visible + .bar2d-focus`), instead of stroking the invisible full-height hit column — so keyboard users get a sensible indicator and no phantom frame floats above short bars.

## Verification (e2e in the dev server, Orange theme)

- Reproduced the bug pre-fix: focusing a bar painted a full-column orange frame identical to the report (accent `#ff9500`, distinct from the Claude segment color, confirmed by pixel sampling).
- Post-fix, clicking a bar leaves `document.activeElement` on `BODY` and paints no ring; hover tooltip still works.
- Post-fix, keyboard focus (`:focus-visible`) draws the ring tightly around the bar itself; `aria-label`/Tab access unchanged.
- `npx tsc --noEmit` passes.