### PR TITLE
Add Cursor plan usage to agent limits

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -113,7 +113,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 |------|------|
 | **2D / 3D 사용량 보기** | 최근 30일 누적 토큰 차트 또는 full-year 3D 타일 그래프. orbit 컨트롤, 카메라 상태 저장, active 타일 자동 fit. |
 | **Overview + 클라이언트 탭** | 데이터가 있는 Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build 탭으로 전환. |
-| **Agent limits** | 로컬 OAuth credential이 있으면 Codex/Claude/Grok session, weekly, credits, model, reset, remaining limit window 표시. |
+| **Agent limits** | 로컬 credential이 있으면 Codex/Claude/Grok/Cursor의 session, weekly, monthly, credits, model, reset, remaining limit window 표시. Cursor는 청구 주기 사용량을 퍼센트로, Auto/API 모델 풀로 나눠 보여줍니다. |
 | **라이브 메뉴바 타이틀** | 오늘의 토큰 / 오늘의 비용 / 전체 토큰 / 전체 비용 / 아이콘만. 토큰 처리량 업데이트는 3분마다 전달됩니다. |
 | **트레이 아이콘 애니메이션** | 회전하는 고양이 또는 party parrot 애니메이션 속도가 실시간 토큰 처리량에 따라 변동. |
 | **네이티브 비브런시 + 글래스모피즘** | 투명 윈도우 + macOS `sidebar` 머티리얼; 라이트/다크 자동 전환. |
@@ -123,7 +123,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 | **인앱 자동 업데이트** | 서명된 Tauri 업데이터. 시작 시 + 30분마다 silent 체크. Settings/트레이 메뉴에서 수동 체크 가능. |
 | **로그인 시 자동 실행** | Tauri autostart 플러그인 — Settings에서 활성화. |
 | **스트릭 & 요약** | 최장/현재 스트릭, 누적 토큰, 누적 비용, 일평균, 최고 사용일. |
-| **텔레메트리 없음** | 사용량 히스토리는 로컬에 머무릅니다. 네트워크 요청은 서명된 업데이트 확인과 credential이 있을 때의 Codex/Claude/Grok quota 조회로 제한됩니다. |
+| **텔레메트리 없음** | 사용량 히스토리는 로컬에 머무릅니다. 네트워크 요청은 서명된 업데이트 확인과 credential이 있을 때의 Codex/Claude/Grok/Cursor quota 조회로 제한됩니다. |
 
 ---
 
@@ -194,7 +194,7 @@ Tokcat은 MIT 라이선스 무료 오픈소스입니다. 구독, 유료 등급, 
 
 ### Tokcat은 제 데이터를 어디로 보내나요?
 
-Tokcat 서버로 사용량 히스토리를 보내지 않고, 텔레메트리·분석·클라우드 동기화·Tokcat 계정이 없습니다. 네트워크 요청은 새 릴리스 확인을 위한 `https://github.com/handlecusion/tokcat/releases/latest/download/latest.json` 조회와, 로컬 credential이 있을 때 Codex/Claude/Grok quota를 직접 조회하는 요청으로 제한됩니다. 토큰 사용 히스토리는 디스크의 세션 로그에서 로컬로 읽습니다.
+Tokcat 서버로 사용량 히스토리를 보내지 않고, 텔레메트리·분석·클라우드 동기화·Tokcat 계정이 없습니다. 네트워크 요청은 새 릴리스 확인을 위한 `https://github.com/handlecusion/tokcat/releases/latest/download/latest.json` 조회와, 로컬 credential이 있을 때 Codex/Claude/Grok/Cursor quota를 직접 조회하는 요청으로 제한됩니다. 토큰 사용 히스토리는 디스크의 세션 로그에서 로컬로 읽습니다.
 
 ### CLI 토큰 사용량 도구와 어떻게 다른가요?
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Tokcat reads local usage logs directly from the Rust backend. On demand from the
 
 For live activity, a JSONL tailer tracks recent growth in supported session logs and turns it into a 10-minute tokens/min signal. The same signal can drive the menu-bar title, the Live session card, and the adaptive tray animation.
 
-For agent-limit cards, Tokcat reads existing Codex, Claude, and Grok Build OAuth credentials and asks those vendors' usage endpoints for quota windows. Those direct vendor calls are separate from the local usage history and are not telemetry.
+For agent-limit cards, Tokcat reads existing Codex, Claude, and Grok Build OAuth credentials plus Cursor's local session token, and asks those vendors' usage endpoints for quota windows. Those direct vendor calls are separate from the local usage history and are not telemetry.
 
 The React frontend renders the payload as an Overview dashboard with per-client tabs. Each tab shares the same year selector, theme picker, 2D/3D usage card, limit card, live session rows, and streak summaries.
 
@@ -130,7 +130,7 @@ Pick between two styles in Settings: the spinning cat or a party parrot. During 
 |---------|---------|
 | **2D / 3D usage views** | Recent 30-day stacked token bars or interactive full-year 3D tile graph with orbit controls, persistent camera, and auto-fit-to-active-tiles framing. |
 | **Overview + client tabs** | Switch between all-client totals and dedicated tabs for Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, and Grok Build when data is present. |
-| **Agent limits** | Codex, Claude, and Grok Build OAuth quota cards show session, weekly, credits, model, reset, and remaining-limit windows when local credentials are available. |
+| **Agent limits** | Codex, Claude, Grok Build, and Cursor quota cards show session, weekly, monthly, credits, model, reset, and remaining-limit windows when local credentials are available. Cursor reports its billing-period allowance as a percentage, split into Auto and API model pools. |
 | **Live menu-bar title** | Today's tokens, today's cost, total tokens, total cost, live tokens/min, or icon-only. Token-rate updates are emitted every 3 minutes. |
 | **Animated tray icon** | Optional spinning cat or party parrot animation whose FPS scales with your real-time token velocity. Native CALayer frame swaps keep the animation smooth in the macOS menu bar. |
 | **Native vibrancy + glassmorphism** | Transparent window with macOS `sidebar` `NSVisualEffectView`; light/dark auto via `prefers-color-scheme`. |
@@ -187,7 +187,9 @@ Tokcat only reads local usage logs that already exist on disk. Open the AI clien
 
 **Agent limits show Error or No quota**
 
-Limit cards use local OAuth credentials from Codex, Claude, and Grok Build. Run `codex login`, `claude`, or `grok login` to refresh those credentials, then choose Refresh Now. API-key-only Codex auth can still produce local token history, but OAuth usage limits require OAuth login.
+Limit cards use local OAuth credentials from Codex, Claude, and Grok Build. Run `codex login`, `claude`, or `grok login` to refresh those credentials, then choose Refresh Now. API-key-only Codex auth can still produce local token history, but OAuth usage limits require OAuth login. Cursor's card reads the session token Cursor stores locally — if it says the session expired, open Cursor and sign in again.
+
+Cursor's limit card is separate from Settings → Cursor usage. That toggle backfills the contribution graph with per-event history from cursor.com; the plan percentage needs no toggle.
 
 **The menu-bar window vanishes when I click anywhere**
 
@@ -236,7 +238,7 @@ Tokcat tracks **Claude Code, OpenAI Codex CLI, Cursor IDE, OpenCode, Google Gemi
 
 ### Does Tokcat send my data anywhere?
 
-Tokcat does not send usage history to Tokcat servers and has no telemetry, analytics, cloud sync, or Tokcat account. It does make network requests for two explicit product functions: update checks against `https://github.com/handlecusion/tokcat/releases/latest/download/latest.json`, and direct Codex/Claude/Grok OAuth quota lookups against those vendors when local credentials are available. Token-usage history is read locally from session logs.
+Tokcat does not send usage history to Tokcat servers and has no telemetry, analytics, cloud sync, or Tokcat account. It does make network requests for two explicit product functions: update checks against `https://github.com/handlecusion/tokcat/releases/latest/download/latest.json`, and direct Codex/Claude/Grok/Cursor quota lookups against those vendors when local credentials are available. Token-usage history is read locally from session logs.
 
 ### How is Tokcat different from CLI token-usage tools?
 

--- a/src-tauri/src/agent_usage.rs
+++ b/src-tauri/src/agent_usage.rs
@@ -17,6 +17,12 @@ const CLAUDE_REFRESH_URL: &str = "https://platform.claude.com/v1/oauth/token";
 const CLAUDE_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const CLAUDE_KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 
+// Cursor current-period usage. A Connect RPC (not one of the cookie-authed
+// cursor.com dashboard endpoints), so the session token from Cursor's state DB
+// goes straight in as a bearer token — no WorkOS cookie or CSRF headers.
+const CURSOR_USAGE_URL: &str =
+    "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage";
+
 // Grok Build OAuth / billing — same endpoints as tokscale's usage/grok module.
 const GROK_SUBSCRIPTIONS_URL: &str = "https://grok.com/rest/subscriptions";
 const GROK_TASK_USAGE_URL: &str = "https://grok.com/rest/tasks/usage";
@@ -246,6 +252,39 @@ struct ClaudeRefreshResponse {
     expires_in: i64,
 }
 
+/// `GetCurrentPeriodUsage` response. Every field is optional: Cursor changes
+/// this payload with its billing model (request quotas → dollar-denominated
+/// included usage), and a missing field must degrade to "no window" rather than
+/// fail the whole snapshot.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorPeriodUsage {
+    #[serde(default)]
+    billing_cycle_end: Option<String>,
+    #[serde(default)]
+    plan_usage: Option<CursorPlanUsage>,
+}
+
+/// Money fields are minor units (cents); percentages are already 0-100.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorPlanUsage {
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    limit: Option<f64>,
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    used: Option<f64>,
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    remaining: Option<f64>,
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    total_percent_used: Option<f64>,
+    /// Cursor's own (auto-routed) model pool.
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    auto_percent_used: Option<f64>,
+    /// Third-party model pool billed at API rates.
+    #[serde(default, deserialize_with = "deserialize_optional_f64")]
+    api_percent_used: Option<f64>,
+}
+
 pub async fn run() -> AgentUsagePayload {
     let generated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
     let mut agents = Vec::new();
@@ -257,6 +296,9 @@ pub async fn run() -> AgentUsagePayload {
     }
     if grok_is_configured() {
         agents.push(fetch_grok().await);
+    }
+    if cursor_is_configured() {
+        agents.push(fetch_cursor().await);
     }
     AgentUsagePayload {
         generated_at,
@@ -293,6 +335,17 @@ fn claude_is_configured() -> bool {
 /// (default `~/.grok/auth.json`). Missing file hides the Grok limits tile.
 fn grok_is_configured() -> bool {
     grok_auth_path().is_file()
+}
+
+/// Whether Cursor is installed *and* signed in. Cursor keeps its session token
+/// in the Electron state DB, so an absent token means "not set up" and the tile
+/// stays hidden rather than showing a permanent sign-in error.
+///
+/// Note this is independent of the `cursorUsage` opt-in, which gates the
+/// historical event fetch feeding the contribution graph. Plan quota is read
+/// here on the same terms as every other agent's limits.
+fn cursor_is_configured() -> bool {
+    crate::cursor_usage::read_state_value("cursorAuth/accessToken").is_some()
 }
 
 async fn fetch_grok() -> AgentUsageSnapshot {
@@ -425,6 +478,83 @@ async fn fetch_claude() -> AgentUsageSnapshot {
             error: Some(error),
         },
     }
+}
+
+async fn fetch_cursor() -> AgentUsageSnapshot {
+    match fetch_cursor_inner().await {
+        Ok(snapshot) => snapshot,
+        Err(error) => AgentUsageSnapshot {
+            client_id: "cursor".to_string(),
+            source: "session".to_string(),
+            updated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+            identity: None,
+            windows: Vec::new(),
+            credits: None,
+            error: Some(error),
+        },
+    }
+}
+
+async fn fetch_cursor_inner() -> Result<AgentUsageSnapshot, String> {
+    let token = crate::cursor_usage::read_access_token()?;
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("build Cursor client: {}", e))?;
+
+    let response = client
+        .post(CURSOR_USAGE_URL)
+        .bearer_auth(&token)
+        // Connect RPC over plain JSON; without this header the server answers
+        // with a protobuf frame instead.
+        .header("Connect-Protocol-Version", "1")
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, "Tokcat")
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .map_err(|e| format!("Cursor usage request failed: {}", e))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("read Cursor usage response: {}", e))?;
+
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err("Cursor session expired. Open Cursor and sign in again.".to_string());
+    }
+    if !status.is_success() {
+        return Err(format!("Cursor usage API returned {}.", status.as_u16()));
+    }
+
+    let usage: CursorPeriodUsage =
+        serde_json::from_str(&body).map_err(|e| format!("decode Cursor usage response: {}", e))?;
+    let now = Utc::now();
+    let windows = cursor_windows(
+        usage.plan_usage.as_ref(),
+        usage.billing_cycle_end.as_deref(),
+        now,
+    );
+    if windows.is_empty() {
+        return Err("Cursor usage API returned no plan windows.".to_string());
+    }
+
+    Ok(AgentUsageSnapshot {
+        client_id: "cursor".to_string(),
+        source: "session".to_string(),
+        updated_at: now.to_rfc3339_opts(SecondsFormat::Millis, true),
+        // Both read locally: Cursor caches them in the same state DB the token
+        // comes from, so the plan label survives even when the API call fails.
+        identity: Some(AgentIdentity {
+            email: crate::cursor_usage::read_state_value("cursorAuth/cachedEmail"),
+            plan: crate::cursor_usage::read_state_value("cursorAuth/stripeMembershipType")
+                .map(clean_plan),
+        }),
+        windows,
+        credits: cursor_credits(usage.plan_usage.as_ref()),
+        error: None,
+    })
 }
 
 async fn fetch_codex_inner() -> Result<AgentUsageSnapshot, String> {
@@ -1060,6 +1190,87 @@ fn claude_credits(extra: Option<&ClaudeExtraUsage>) -> Option<CreditsSnapshot> {
         remaining,
         unlimited: false,
     })
+}
+
+/// Map the current billing period onto usage windows. "Monthly" is the headline
+/// number the Cursor dashboard shows as a percentage; "Auto" and "API" split it
+/// by model pool and only appear when Cursor reports them.
+fn cursor_windows(
+    plan: Option<&CursorPlanUsage>,
+    billing_cycle_end: Option<&str>,
+    now: DateTime<Utc>,
+) -> Vec<UsageWindow> {
+    let Some(plan) = plan else {
+        return Vec::new();
+    };
+    let resets_at = billing_cycle_end.and_then(parse_cursor_datetime);
+    let total = plan.total_percent_used.or_else(|| {
+        // Older payloads report only the dollar figures; derive the percentage
+        // from whichever pair is present.
+        let limit = plan.limit.filter(|limit| *limit > 0.0)?;
+        let used = plan
+            .used
+            .or_else(|| plan.remaining.map(|remaining| limit - remaining))?;
+        Some((used / limit) * 100.0)
+    });
+    [
+        ("Monthly", total),
+        ("Auto", plan.auto_percent_used),
+        ("API", plan.api_percent_used),
+    ]
+    .into_iter()
+    .filter_map(|(label, percent)| cursor_window(label, percent?, resets_at, now))
+    .collect()
+}
+
+fn cursor_window(
+    label: &str,
+    used_percent: f64,
+    resets_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> Option<UsageWindow> {
+    if !used_percent.is_finite() {
+        return None;
+    }
+    let used = used_percent.clamp(0.0, 100.0);
+    Some(UsageWindow {
+        label: label.to_string(),
+        used_percent: used,
+        remaining_percent: (100.0 - used).max(0.0),
+        resets_at: resets_at.map(|date| date.to_rfc3339_opts(SecondsFormat::Millis, true)),
+        reset_text: resets_at.map(|date| reset_text(date, now)),
+    })
+}
+
+/// Dollars left in the monthly included-usage allowance. Cursor reports money in
+/// cents; `CreditsSnapshot::remaining` is major units, matching Claude's.
+fn cursor_credits(plan: Option<&CursorPlanUsage>) -> Option<CreditsSnapshot> {
+    let plan = plan?;
+    // A missing or zero limit means "not reported", not "unlimited" — claiming
+    // unlimited on an Ultra plan we can't actually read would be worse than
+    // showing nothing.
+    let limit = plan.limit.filter(|limit| *limit > 0.0)?;
+    let remaining = plan
+        .remaining
+        .or_else(|| plan.used.map(|used| limit - used))
+        .filter(|remaining| remaining.is_finite())?;
+    Some(CreditsSnapshot {
+        remaining: Some((remaining / 100.0).max(0.0)),
+        unlimited: false,
+    })
+}
+
+/// `billingCycleEnd` shows up as both an RFC3339 timestamp and epoch millis
+/// (string-encoded, as Connect does with int64) — accept either.
+fn parse_cursor_datetime(value: &str) -> Option<DateTime<Utc>> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(parsed) = parse_datetime(value) {
+        return Some(parsed);
+    }
+    Utc.timestamp_millis_opt(value.parse().ok()?).single()
 }
 
 fn format_currency_minor_units(value: f64, currency: Option<&str>) -> String {
@@ -2004,6 +2215,119 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cursor_now() -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(1_781_000_000_000)
+            .single()
+            .unwrap()
+    }
+
+    #[test]
+    fn cursor_windows_use_server_percentages_and_split_pools() {
+        let plan = CursorPlanUsage {
+            limit: Some(2000.0),
+            used: Some(812.0),
+            remaining: Some(1188.0),
+            total_percent_used: Some(40.6),
+            auto_percent_used: Some(12.1),
+            api_percent_used: Some(28.5),
+        };
+        let windows = cursor_windows(Some(&plan), Some("2026-08-01T00:00:00Z"), cursor_now());
+        let labels: Vec<_> = windows.iter().map(|w| w.label.as_str()).collect();
+        assert_eq!(labels, ["Monthly", "Auto", "API"]);
+        assert_eq!(windows[0].used_percent, 40.6);
+        assert!((windows[0].remaining_percent - 59.4).abs() < 1e-9);
+        assert_eq!(
+            windows[0].resets_at.as_deref(),
+            Some("2026-08-01T00:00:00.000Z")
+        );
+        assert!(windows[0].reset_text.is_some());
+    }
+
+    #[test]
+    fn cursor_monthly_percent_falls_back_to_dollar_figures() {
+        // Older payloads carry only the money fields. `remaining` alone is
+        // enough: used = limit - remaining.
+        let plan = CursorPlanUsage {
+            limit: Some(2000.0),
+            remaining: Some(1500.0),
+            ..Default::default()
+        };
+        let windows = cursor_windows(Some(&plan), None, cursor_now());
+        assert_eq!(windows.len(), 1, "no pool split without the percent fields");
+        assert_eq!(windows[0].label, "Monthly");
+        assert_eq!(windows[0].used_percent, 25.0);
+        assert!(windows[0].resets_at.is_none());
+    }
+
+    #[test]
+    fn cursor_windows_empty_without_usable_fields() {
+        // An Ultra/unlimited or unrecognized payload must yield no windows so
+        // the caller surfaces "no plan windows" instead of a bogus 0%.
+        assert!(cursor_windows(Some(&CursorPlanUsage::default()), None, cursor_now()).is_empty());
+        assert!(cursor_windows(None, None, cursor_now()).is_empty());
+        let zero_limit = CursorPlanUsage {
+            limit: Some(0.0),
+            used: Some(0.0),
+            ..Default::default()
+        };
+        assert!(cursor_windows(Some(&zero_limit), None, cursor_now()).is_empty());
+    }
+
+    #[test]
+    fn cursor_credits_report_dollars_left_and_never_guess_unlimited() {
+        let plan = CursorPlanUsage {
+            limit: Some(2000.0),
+            used: Some(812.0),
+            ..Default::default()
+        };
+        let credits = cursor_credits(Some(&plan)).expect("credits from limit + used");
+        assert!((credits.remaining.unwrap() - 11.88).abs() < 1e-9);
+        assert!(!credits.unlimited);
+        // No limit reported => no credits row, rather than a false "unlimited".
+        assert!(cursor_credits(Some(&CursorPlanUsage::default())).is_none());
+    }
+
+    #[test]
+    fn cursor_billing_cycle_end_accepts_rfc3339_and_epoch_millis() {
+        let from_rfc = parse_cursor_datetime("2026-08-01T00:00:00Z").unwrap();
+        let from_millis = parse_cursor_datetime("1785542400000").unwrap();
+        assert_eq!(from_rfc.timestamp_millis(), 1785542400000);
+        assert_eq!(from_millis, from_rfc);
+        assert!(parse_cursor_datetime("  ").is_none());
+        assert!(parse_cursor_datetime("not-a-date").is_none());
+    }
+
+    #[test]
+    fn cursor_response_tolerates_string_encoded_numbers() {
+        // Connect encodes int64 as JSON strings; percentages may arrive either
+        // way. Both must decode rather than dropping the window.
+        let usage: CursorPeriodUsage = serde_json::from_str(
+            r#"{"billingCycleEnd":"1785542400000","planUsage":{"limit":"2000","used":"500","totalPercentUsed":"25"}}"#,
+        )
+        .expect("decode");
+        let windows = cursor_windows(
+            usage.plan_usage.as_ref(),
+            usage.billing_cycle_end.as_deref(),
+            cursor_now(),
+        );
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].used_percent, 25.0);
+        assert_eq!(
+            windows[0].resets_at.as_deref(),
+            Some("2026-08-01T00:00:00.000Z")
+        );
+    }
+
+    #[test]
+    fn cursor_unknown_fields_do_not_break_decoding() {
+        // Cursor adds fields as its billing model changes; unknown ones must be
+        // ignored, and a payload with no planUsage must still decode.
+        let usage: CursorPeriodUsage =
+            serde_json::from_str(r#"{"displayMessage":"hi","spendLimitUsage":{"limitType":"x"}}"#)
+                .expect("decode");
+        assert!(usage.plan_usage.is_none());
+    }
 
     #[test]
     fn codex_tile_gated_on_auth_json_presence() {

--- a/src-tauri/src/cursor_usage.rs
+++ b/src-tauri/src/cursor_usage.rs
@@ -89,10 +89,28 @@ fn state_db_path() -> Result<PathBuf, String> {
     Ok(home()?.join("Library/Application Support/Cursor/User/globalStorage/state.vscdb"))
 }
 
+/// Read one value out of Cursor's Electron key/value store, or None when Cursor
+/// isn't installed / the key is absent. Cursor stores JSON scalars, so plain
+/// strings arrive quoted — strip them the same way `read_access_token` does.
+pub(crate) fn read_state_value(key: &str) -> Option<String> {
+    let path = state_db_path().ok()?;
+    if !path.exists() {
+        return None;
+    }
+    let conn = Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let value: String = conn
+        .query_row("SELECT value FROM ItemTable WHERE key = ?1", [key], |row| {
+            row.get(0)
+        })
+        .ok()?;
+    let value = value.trim().trim_matches('"').trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
 /// Read Cursor's live OAuth access token from its Electron key/value store.
 /// Cursor refreshes this token in place; the macOS Keychain copy is only written
 /// at login and goes stale, so the state DB is the reliable source.
-fn read_access_token() -> Result<String, String> {
+pub(crate) fn read_access_token() -> Result<String, String> {
     let path = state_db_path()?;
     if !path.exists() {
         return Err("Cursor not found. Install Cursor and sign in to enable usage.".to_string());

--- a/src/components/AgentLimitsCard.tsx
+++ b/src/components/AgentLimitsCard.tsx
@@ -25,6 +25,8 @@ const LIMIT_ROWS: Record<string, LimitRow[]> = {
   // Placeholder rows while OAuth quota is loading; real windows come from
   // the backend (Monthly credits, Frequent/Occasional task limits, …).
   grok: [{ label: 'Monthly' }],
+  // Cursor's billing period; the backend adds Auto/API pool rows when present.
+  cursor: [{ label: 'Monthly' }],
 }
 
 function normalizeTraceClient(id: string): string {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -57,6 +57,7 @@ const PLAN_PROVIDER_OPTIONS: { id: PlanProvider; label: string }[] = [
   { id: 'claude', label: PLAN_PROVIDER_LABELS.claude },
   { id: 'codex', label: PLAN_PROVIDER_LABELS.codex },
   { id: 'grok', label: PLAN_PROVIDER_LABELS.grok },
+  { id: 'cursor', label: PLAN_PROVIDER_LABELS.cursor },
 ]
 
 const PLAN_DISPLAY_OPTIONS: { id: PlanDisplayMode; label: string }[] = [

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -12,10 +12,11 @@ export type TrayMode =
   | 'hidden'
 export type AnimationStyle = 'cat' | 'parrot'
 
-// Providers that expose an OAuth plan/quota cap, so a "% used / % left" is
-// meaningful. Log-parsed clients (cursor, gemini, copilot, …) only report
-// cumulative tokens and are intentionally excluded here.
-export type PlanProvider = 'auto' | 'claude' | 'codex' | 'grok'
+// Providers that expose a plan/quota cap, so a "% used / % left" is meaningful.
+// Cursor qualifies via its billing-period API (dollar-denominated monthly
+// allowance), not via logs. Purely log-parsed clients (gemini, copilot, …) only
+// report cumulative tokens and are intentionally excluded here.
+export type PlanProvider = 'auto' | 'claude' | 'codex' | 'grok' | 'cursor'
 export type PlanDisplayMode = 'used' | 'left'
 
 // Short labels shown in the (text-only) menubar title. The status item can't
@@ -24,8 +25,9 @@ export const PLAN_PROVIDER_LABELS: Record<Exclude<PlanProvider, 'auto'>, string>
   claude: 'Claude',
   codex: 'Codex',
   grok: 'Grok',
+  cursor: 'Cursor',
 }
-export const PLAN_CAPABLE_PROVIDERS = ['claude', 'codex', 'grok'] as const
+export const PLAN_CAPABLE_PROVIDERS = ['claude', 'codex', 'grok', 'cursor'] as const
 
 export interface Settings {
   trayMode: TrayMode


### PR DESCRIPTION
Closes #22 (the plan-percentage half).

## What

Cursor was the one supported client with no plan-percentage card. Its usage only reached the contribution graph as tokens and cost, so there was no way to see how much of the monthly allowance was left — which is what @z0ph asked for in #22.

This adds a Cursor tile to the agent-limits card and makes Cursor selectable as a menubar `plan_percent` source.

## How

`POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage` returns the current billing period: `planUsage.{limit,used,remaining,totalPercentUsed,autoPercentUsed,apiPercentUsed}` plus `billingCycleEnd`. It's a Connect RPC rather than one of the cookie-authed `cursor.com/api/dashboard/*` endpoints, so the session token `cursor_usage` already reads from Cursor's state DB goes in as a plain bearer token — no WorkOS cookie, no CSRF headers.

Windows produced: **Monthly** (headline), plus **Auto** / **API** when Cursor reports the pool split. Reset comes from `billingCycleEnd`. Identity (email, plan tier) is read locally from the same state DB, so the plan label survives a failed API call.

## Gating

The card is gated on Cursor being signed in — **not** on the `cursorUsage` toggle. That toggle backfills contribution-graph history from cursor.com; plan quota is now read on the same terms as Codex/Claude/Grok limits. Without this, a fresh install shows nothing until the user finds a setting, which is the other half of what #22 reported.

## Not verified against a live account

The response schema is derived from a community extension that consumes this endpoint in production, not from a captured response — my own Cursor session token is expired. Decoding is defensive: every field optional, string-encoded numbers accepted, unknown fields ignored, and a missing limit yields no window rather than a bogus 0% or a guessed "unlimited". Worst case on a schema mismatch is "Cursor usage API returned no plan windows" on the tile, not a broken refresh.

Two cases worth confirming on a real account after merge:
- Ultra / unlimited plans — does `limit` come back 0, absent, or a real number?
- Team accounts — is `planUsage` populated at all?

## Tests

7 unit tests covering the percent mapping, the dollar-figure fallback, the empty cases, credits, `billingCycleEnd` in both RFC3339 and epoch-millis form, and string-encoded numbers. `cargo test --lib` 50 passed, clippy clean, `tsc --noEmit` and `npm run build` clean.

@z0ph — this is the plan-percentage feature you asked about. Separately, for the "Cursor usage isn't displayed" part: that's the **Settings → Cursor usage → Fetch from cursor.com** toggle, which is off by default. If turning it on shows an error, the message would tell us whether Cursor 3.10 moved the local session token — worth knowing either way.