### PR TITLE
Show Cursor's model pools instead of a blended total

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -113,7 +113,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 |------|------|
 | **2D / 3D 사용량 보기** | 최근 30일 누적 토큰 차트 또는 full-year 3D 타일 그래프. orbit 컨트롤, 카메라 상태 저장, active 타일 자동 fit. |
 | **Overview + 클라이언트 탭** | 데이터가 있는 Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build 탭으로 전환. |
-| **Agent limits** | 로컬 credential이 있으면 Codex/Claude/Grok/Cursor의 session, weekly, monthly, credits, model, reset, remaining limit window 표시. Cursor는 청구 주기 사용량을 퍼센트로, Auto/API 모델 풀로 나눠 보여줍니다. |
+| **Agent limits** | 로컬 credential이 있으면 Codex/Claude/Grok/Cursor의 session, weekly, monthly, credits, model, reset, remaining limit window 표시. Cursor는 청구 주기의 모델 풀별(Cursor Models, Other Models)로 한 줄씩 보여주며, Cursor 자체 Plan & Usage 화면과 동일한 수치입니다. |
 | **라이브 메뉴바 타이틀** | 오늘의 토큰 / 오늘의 비용 / 전체 토큰 / 전체 비용 / 아이콘만. 토큰 처리량 업데이트는 3분마다 전달됩니다. |
 | **트레이 아이콘 애니메이션** | 회전하는 고양이 또는 party parrot 애니메이션 속도가 실시간 토큰 처리량에 따라 변동. |
 | **네이티브 비브런시 + 글래스모피즘** | 투명 윈도우 + macOS `sidebar` 머티리얼; 라이트/다크 자동 전환. |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Pick between two styles in Settings: the spinning cat or a party parrot. During 
 |---------|---------|
 | **2D / 3D usage views** | Recent 30-day stacked token bars or interactive full-year 3D tile graph with orbit controls, persistent camera, and auto-fit-to-active-tiles framing. |
 | **Overview + client tabs** | Switch between all-client totals and dedicated tabs for Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, and Grok Build when data is present. |
-| **Agent limits** | Codex, Claude, Grok Build, and Cursor quota cards show session, weekly, monthly, credits, model, reset, and remaining-limit windows when local credentials are available. Cursor reports its billing-period allowance as a percentage, split into Auto and API model pools. |
+| **Agent limits** | Codex, Claude, Grok Build, and Cursor quota cards show session, weekly, monthly, credits, model, reset, and remaining-limit windows when local credentials are available. Cursor shows one row per billing-period model pool (Cursor Models, Other Models), matching its own Plan & Usage page. |
 | **Live menu-bar title** | Today's tokens, today's cost, total tokens, total cost, live tokens/min, or icon-only. Token-rate updates are emitted every 3 minutes. |
 | **Animated tray icon** | Optional spinning cat or party parrot animation whose FPS scales with your real-time token velocity. Native CALayer frame swaps keep the animation smooth in the macOS menu bar. |
 | **Native vibrancy + glassmorphism** | Transparent window with macOS `sidebar` `NSVisualEffectView`; light/dark auto via `prefers-color-scheme`. |

--- a/src-tauri/src/agent_usage.rs
+++ b/src-tauri/src/agent_usage.rs
@@ -485,7 +485,7 @@ async fn fetch_cursor() -> AgentUsageSnapshot {
         Ok(snapshot) => snapshot,
         Err(error) => AgentUsageSnapshot {
             client_id: "cursor".to_string(),
-            source: "session".to_string(),
+            source: "oauth".to_string(),
             updated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
             identity: None,
             windows: Vec::new(),
@@ -542,7 +542,10 @@ async fn fetch_cursor_inner() -> Result<AgentUsageSnapshot, String> {
 
     Ok(AgentUsageSnapshot {
         client_id: "cursor".to_string(),
-        source: "session".to_string(),
+        // Cursor's session token is an OAuth access token issued by
+        // authentication.cursor.sh; the tile renders this verbatim as its
+        // badge, and "SESSION" there reads like a session-length quota.
+        source: "oauth".to_string(),
         updated_at: now.to_rfc3339_opts(SecondsFormat::Millis, true),
         // Both read locally: Cursor caches them in the same state DB the token
         // comes from, so the plan label survives even when the API call fails.
@@ -1192,9 +1195,15 @@ fn claude_credits(extra: Option<&ClaudeExtraUsage>) -> Option<CreditsSnapshot> {
     })
 }
 
-/// Map the current billing period onto usage windows. "Monthly" is the headline
-/// number the Cursor dashboard shows as a percentage; "Auto" and "API" split it
-/// by model pool and only appear when Cursor reports them.
+/// Map the current billing period onto usage windows, mirroring what Cursor's
+/// own Plan & Usage page shows: one bar per model pool, and no combined bar.
+///
+/// `totalPercentUsed` blends the pools by dollars, so on a plan whose pools
+/// differ wildly in size (Ultra bundles a far larger Cursor-models allowance
+/// than its API allowance) it reads far below the pool that's actually running
+/// out — 3% while the binding pool sits at 14%. That's the opposite of useful
+/// for spend control, so it's a fallback for accounts that don't report the
+/// split, never the headline.
 fn cursor_windows(
     plan: Option<&CursorPlanUsage>,
     billing_cycle_end: Option<&str>,
@@ -1204,6 +1213,19 @@ fn cursor_windows(
         return Vec::new();
     };
     let resets_at = billing_cycle_end.and_then(parse_cursor_datetime);
+    // Labels match Cursor's own vocabulary so the rows can be read straight
+    // against its dashboard.
+    let pools: Vec<UsageWindow> = [
+        ("Cursor Models", plan.auto_percent_used),
+        ("Other Models", plan.api_percent_used),
+    ]
+    .into_iter()
+    .filter_map(|(label, percent)| cursor_window(label, percent?, resets_at, now))
+    .collect();
+    if !pools.is_empty() {
+        return pools;
+    }
+
     let total = plan.total_percent_used.or_else(|| {
         // Older payloads report only the dollar figures; derive the percentage
         // from whichever pair is present.
@@ -1213,14 +1235,10 @@ fn cursor_windows(
             .or_else(|| plan.remaining.map(|remaining| limit - remaining))?;
         Some((used / limit) * 100.0)
     });
-    [
-        ("Monthly", total),
-        ("Auto", plan.auto_percent_used),
-        ("API", plan.api_percent_used),
-    ]
-    .into_iter()
-    .filter_map(|(label, percent)| cursor_window(label, percent?, resets_at, now))
-    .collect()
+    total
+        .and_then(|total| cursor_window("Monthly", total, resets_at, now))
+        .into_iter()
+        .collect()
 }
 
 fn cursor_window(
@@ -2223,25 +2241,53 @@ mod tests {
     }
 
     #[test]
-    fn cursor_windows_use_server_percentages_and_split_pools() {
+    fn cursor_windows_report_pools_and_drop_the_blended_total() {
+        // Numbers from the Ultra account in #22: the dashboard showed 0% and
+        // 14% for the two pools while totalPercentUsed read 3%. Surfacing that
+        // 3% hides the pool actually running out, so the pools win outright.
         let plan = CursorPlanUsage {
-            limit: Some(2000.0),
-            used: Some(812.0),
-            remaining: Some(1188.0),
-            total_percent_used: Some(40.6),
-            auto_percent_used: Some(12.1),
-            api_percent_used: Some(28.5),
+            limit: Some(186_700.0),
+            used: Some(5600.0),
+            remaining: Some(181_100.0),
+            total_percent_used: Some(3.0),
+            auto_percent_used: Some(0.0),
+            api_percent_used: Some(14.0),
         };
-        let windows = cursor_windows(Some(&plan), Some("2026-08-01T00:00:00Z"), cursor_now());
+        let windows = cursor_windows(Some(&plan), Some("2026-08-22T00:00:00Z"), cursor_now());
         let labels: Vec<_> = windows.iter().map(|w| w.label.as_str()).collect();
-        assert_eq!(labels, ["Monthly", "Auto", "API"]);
-        assert_eq!(windows[0].used_percent, 40.6);
-        assert!((windows[0].remaining_percent - 59.4).abs() < 1e-9);
+        assert_eq!(labels, ["Cursor Models", "Other Models"]);
+        assert_eq!(windows[0].used_percent, 0.0);
+        assert_eq!(windows[1].used_percent, 14.0);
+        assert!((windows[1].remaining_percent - 86.0).abs() < 1e-9);
         assert_eq!(
-            windows[0].resets_at.as_deref(),
-            Some("2026-08-01T00:00:00.000Z")
+            windows[1].resets_at.as_deref(),
+            Some("2026-08-22T00:00:00.000Z")
         );
-        assert!(windows[0].reset_text.is_some());
+        assert!(windows[1].reset_text.is_some());
+    }
+
+    #[test]
+    fn cursor_reports_a_single_pool_when_only_one_is_present() {
+        let plan = CursorPlanUsage {
+            api_percent_used: Some(14.0),
+            total_percent_used: Some(3.0),
+            ..Default::default()
+        };
+        let windows = cursor_windows(Some(&plan), None, cursor_now());
+        let labels: Vec<_> = windows.iter().map(|w| w.label.as_str()).collect();
+        assert_eq!(labels, ["Other Models"]);
+    }
+
+    #[test]
+    fn cursor_falls_back_to_the_blended_total_without_a_pool_split() {
+        let plan = CursorPlanUsage {
+            total_percent_used: Some(41.0),
+            ..Default::default()
+        };
+        let windows = cursor_windows(Some(&plan), None, cursor_now());
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].label, "Monthly");
+        assert_eq!(windows[0].used_percent, 41.0);
     }
 
     #[test]

--- a/src/components/AgentLimitsCard.tsx
+++ b/src/components/AgentLimitsCard.tsx
@@ -25,8 +25,9 @@ const LIMIT_ROWS: Record<string, LimitRow[]> = {
   // Placeholder rows while OAuth quota is loading; real windows come from
   // the backend (Monthly credits, Frequent/Occasional task limits, …).
   grok: [{ label: 'Monthly' }],
-  // Cursor's billing period; the backend adds Auto/API pool rows when present.
-  cursor: [{ label: 'Monthly' }],
+  // Cursor's two billing-period pools; accounts that don't report the split
+  // get a single Monthly row from the backend instead.
+  cursor: [{ label: 'Cursor Models' }, { label: 'Other Models' }],
 }
 
 function normalizeTraceClient(id: string): string {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import {
   AnimationStyle,
   ANIMATION_STYLE_LABELS,
+  mostConstrained,
   PlanDisplayMode,
   PlanProvider,
   PLAN_PROVIDER_LABELS,
@@ -171,9 +172,13 @@ export function SettingsPanel({ open, onClose, settings, onChange, agentUsage }:
       return
     }
     // Pin a valid window for the chosen provider: keep the current one if it
-    // still exists, else default to the provider's first window.
+    // still exists, else default to the one closest to its cap. Defaulting to
+    // the first window can land on the emptiest pool — picking Cursor would
+    // show its untouched Cursor Models row rather than the one running out.
     const wins = windowsFor(provider)
-    const planWindow = wins.includes(settings.planWindow) ? settings.planWindow : wins[0] ?? settings.planWindow
+    const windows = planSnapshots.get(provider)?.windows ?? []
+    const fallback = windows.length ? mostConstrained(windows).label : settings.planWindow
+    const planWindow = wins.includes(settings.planWindow) ? settings.planWindow : fallback
     onChange({ ...settings, planProvider: provider, planWindow })
   }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,5 +1,5 @@
 import type { Stats } from './types'
-import type { AgentUsagePayload } from './agentUsage'
+import type { AgentUsagePayload, UsageWindow } from './agentUsage'
 import { humanizeTokens, formatCost, isoDate } from './format'
 
 export type TrayMode =
@@ -117,11 +117,19 @@ function clampPercent(value: number): number {
   return Math.round(Math.min(100, Math.max(0, value)))
 }
 
+// The window closest to its cap. Used both for 'auto' mode and as the fallback
+// when a pinned label is gone: providers add and drop windows over time (Cursor
+// moved to per-pool rows, Claude's model windows come and go), and the first
+// window is an arbitrary pick that can easily be the emptiest one.
+export function mostConstrained(windows: UsageWindow[]): UsageWindow {
+  return windows.reduce((worst, w) => (w.usedPercent > worst.usedPercent ? w : worst))
+}
+
 // Resolve which provider/window the menubar should show. In 'auto' mode we pick
 // the window closest to its cap (highest usedPercent) across all plan-capable
 // providers; otherwise we honor the pinned provider + window, falling back to
-// that provider's first window if the pinned label is gone. Returns null when
-// no plan-capable provider has any windows yet (loading / not signed in).
+// that provider's most-constrained window if the pinned label is gone. Returns
+// null when no plan-capable provider has any windows yet (loading / signed out).
 function pickPlanWindow(
   agentUsage: AgentUsagePayload | null,
   provider: PlanProvider,
@@ -146,7 +154,7 @@ function pickPlanWindow(
 
   const agent = candidates.find(a => a.clientId === provider)
   if (!agent) return null
-  const w = agent.windows.find(x => x.label === windowLabel) ?? agent.windows[0]
+  const w = agent.windows.find(x => x.label === windowLabel) ?? mostConstrained(agent.windows)
   return { providerId: agent.clientId, usedPercent: w.usedPercent, remainingPercent: w.remainingPercent }
 }
 


### PR DESCRIPTION
Follow-up to #39, from @z0ph's feedback in #22 — thanks for testing it so fast and for the side-by-side screenshot, which made the problem obvious.

## The problem

0.1.40 made `totalPercentUsed` the headline Cursor number. It blends both billing pools by dollars, so on a plan whose pools differ wildly in size it reads far below whichever pool is actually running out. On the Ultra account in #22:

| Cursor's Plan & Usage | Tokcat 0.1.40 |
|---|---|
| Cursor Models — 0% used | Auto — 100% left ✅ |
| Other Models — 14% used | API — 86% left ✅ |
| *(no combined bar)* | **Monthly — 97% left** ❌ |

The pools were right. The aggregate was the one the menubar showed: **3% used**, while the binding pool was at 14%. For someone tracking spend, that's the one number that must not be wrong.

## Changes

**Pools become the headline.** One row per pool, labeled as Cursor labels them — `Cursor Models` / `Other Models` instead of `Auto` / `API`. Cursor's own page shows no combined bar, and now neither do we; the blended total remains as a fallback for accounts that don't report a split.

**Most-constrained fallback for the menubar.** `pickPlanWindow` fell back to `windows[0]` when a pinned label was gone. This change removes `Monthly` for most Cursor accounts, so that path now fires for anyone who pinned Cursor — and `windows[0]` would be `Cursor Models`, likely the emptiest pool. It now falls back to the window closest to its cap. Same fix for the default the settings panel picks when you pin a provider.

This is a behavior change beyond Cursor: pinning a window that later disappears (Claude's model windows come and go) now resolves to the most-constrained window rather than an arbitrary first one. It only applies when the pin is already broken.

**Badge fix.** Cursor's snapshot declared `source: "session"`, which the tile renders verbatim — so it showed `SESSION` where every other agent shows `OAUTH`, reading like a session-length quota. Cursor's token is an OAuth access token issued by `authentication.cursor.sh`; the source is now `oauth`.

## On the schema

#39 shipped without a live account to verify against. The screenshot confirms the mapping was right: `autoPercentUsed` ↔ Cursor Models, `apiPercentUsed` ↔ Other Models, both matching the dashboard exactly, and an Ultra account returns real percentages rather than the unlimited case I'd guessed at.

## Tests

`cargo test --lib` 52 passed (4 Cursor window tests reworked around the pool-first behavior, using the numbers from the screenshot), clippy clean, `tsc --noEmit` and `npm run build` clean.