### PR TITLE
Refresh agent quota cards every 30 minutes

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -113,7 +113,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 |------|------|
 | **2D / 3D 사용량 보기** | 최근 30일 누적 토큰 차트 또는 full-year 3D 타일 그래프. orbit 컨트롤, 카메라 상태 저장, active 타일 자동 fit. |
 | **Overview + 클라이언트 탭** | 데이터가 있는 Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build 탭으로 전환. |
-| **Agent limits** | 로컬 credential이 있으면 Codex/Claude/Grok/Cursor의 session, weekly, monthly, credits, model, reset, remaining limit window 표시. Cursor는 청구 주기의 모델 풀별(Cursor Models, Other Models)로 한 줄씩 보여주며, Cursor 자체 Plan & Usage 화면과 동일한 수치입니다. |
+| **Agent limits** | 로컬 credential이 있으면 Codex/Claude/Grok/Cursor의 session, weekly, monthly, credits, model, reset, remaining limit window 표시. Cursor는 청구 주기의 모델 풀별(Cursor Models, Other Models)로 한 줄씩 보여주며, Cursor 자체 Plan & Usage 화면과 동일한 수치입니다. 한도 값은 실행 시, 이후 30분마다, 그리고 Refresh Now를 누를 때 다시 조회합니다. |
 | **라이브 메뉴바 타이틀** | 오늘의 토큰 / 오늘의 비용 / 전체 토큰 / 전체 비용 / 아이콘만. 토큰 처리량 업데이트는 3분마다 전달됩니다. |
 | **트레이 아이콘 애니메이션** | 회전하는 고양이 또는 party parrot 애니메이션 속도가 실시간 토큰 처리량에 따라 변동. |
 | **네이티브 비브런시 + 글래스모피즘** | 투명 윈도우 + macOS `sidebar` 머티리얼; 라이트/다크 자동 전환. |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Pick between two styles in Settings: the spinning cat or a party parrot. During 
 |---------|---------|
 | **2D / 3D usage views** | Recent 30-day stacked token bars or interactive full-year 3D tile graph with orbit controls, persistent camera, and auto-fit-to-active-tiles framing. |
 | **Overview + client tabs** | Switch between all-client totals and dedicated tabs for Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, and Grok Build when data is present. |
-| **Agent limits** | Codex, Claude, Grok Build, and Cursor quota cards show session, weekly, monthly, credits, model, reset, and remaining-limit windows when local credentials are available. Cursor shows one row per billing-period model pool (Cursor Models, Other Models), matching its own Plan & Usage page. |
+| **Agent limits** | Codex, Claude, Grok Build, and Cursor quota cards show session, weekly, monthly, credits, model, reset, and remaining-limit windows when local credentials are available. Cursor shows one row per billing-period model pool (Cursor Models, Other Models), matching its own Plan & Usage page. Quotas are re-fetched on launch, every 30 minutes after that, and on demand from Refresh Now. |
 | **Live menu-bar title** | Today's tokens, today's cost, total tokens, total cost, live tokens/min, or icon-only. Token-rate updates are emitted every 3 minutes. |
 | **Animated tray icon** | Optional spinning cat or party parrot animation whose FPS scales with your real-time token velocity. Native CALayer frame swaps keep the animation smooth in the macOS menu bar. |
 | **Native vibrancy + glassmorphism** | Transparent window with macOS `sidebar` `NSVisualEffectView`; light/dark auto via `prefers-color-scheme`. |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,9 @@ import { getClientStyle } from './lib/clients'
 
 const THEME_KEY = 'tokcat:theme:v1'
 const USAGE_VIEW_KEY = 'tokcat:usageview:v1'
+// Mirrors REFRESH_SECS in src-tauri/src/lib.rs so quota tiles and the graph
+// payload age at the same rate.
+const AGENT_USAGE_REFRESH_MS = 30 * 60 * 1000
 
 function loadTheme(): ThemeName {
   try {
@@ -44,8 +47,12 @@ function defaultYear(): string {
 export default function App() {
   const [year, setYear] = useState<string>(defaultYear())
   const [refreshTick, setRefreshTick] = useState(0)
+  // Bumped by the background timer below, and summed into the agent-usage key
+  // rather than folded into `refreshTick` so an automatic re-fetch doesn't spin
+  // the header icon or duplicate the graph rebuild the backend already runs.
+  const [agentUsageTick, setAgentUsageTick] = useState(0)
   const { payload, error } = useGraphStream(year)
-  const agentUsage = useAgentUsage(refreshTick)
+  const agentUsage = useAgentUsage(refreshTick + agentUsageTick)
   const [theme, setTheme] = useState<ThemeName>(() => loadTheme())
   const [isDark, setIsDark] = useState<boolean>(() =>
     typeof window !== 'undefined' && window.matchMedia
@@ -153,6 +160,17 @@ export default function App() {
     const id = window.setInterval(() => {
       void checkForUpdatesSilent()
     }, 30 * 60 * 1000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  // Agent limits are fetched on mount and on manual refresh only. The backend
+  // refresh loop rebuilds the contribution graph, not `get_agent_usage`, so
+  // without this tick the quota tiles — and a `plan_percent` menubar title —
+  // stay pinned to whatever the quotas were when Tokcat launched.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setAgentUsageTick(t => t + 1)
+    }, AGENT_USAGE_REFRESH_MS)
     return () => window.clearInterval(id)
   }, [])
 


### PR DESCRIPTION
Follow-up to #39 / #41 — from my side of #22. The Cursor pool numbers those PRs added are correct; they just stop updating after launch.

## The problem

`agent_usage::run()` — the call that hits `GetCurrentPeriodUsage` and builds the Cursor pool windows — only runs when the frontend invokes `get_agent_usage`, and the frontend only invokes it when the key passed to `useAgentUsage` changes:

- `useAgentUsage` re-fetches on its `refreshKey` dep alone (`src/hooks/useAgentUsage.ts`).
- `refreshTick` is bumped by the header refresh button, ⌘R, the tray *Refresh Now* item, and the Cursor-usage toggle — nothing else (`src/App.tsx`).
- The main webview is created hidden at launch and lives for the whole session, so the mount fetch happens exactly once per launch.

The 30-minute loop in `spawn_refresh_loop` (`src-tauri/src/lib.rs`, `REFRESH_SECS = 1800`) rebuilds `usage_graph` and, when the toggle is on, `cursor_usage::refresh_cache`. It never touches `agent_usage`. The one 30-minute `setInterval` already in `App.tsx` belongs to `checkForUpdatesSilent`.

Net effect with **Settings → Menubar → Plan usage → Cursor**: the percentage is pinned to launch time. It doesn't look broken either — the tray-title effect keeps re-running because `overviewStats` and `tokensPerMin` change (rate updates land every 3 minutes), so it repaints a stale number indefinitely. Opening the popover doesn't help; the `popover-shown` listener only resizes the window. On a menubar app that stays running for days, the displayed quota can be days old.

This isn't Cursor-specific. Codex, Claude and Grok Build tiles come from the same `agent_usage::run()` and are equally frozen — Cursor is just where it became visible, because it's the pool that moves fastest during a work session.

## Changes

A 30-minute tick for agent usage, matching `REFRESH_SECS` so the quota tiles and the graph payload age at the same rate.

The tick bumps `agentUsageTick`, kept separate from `refreshTick` and summed into the hook's key. Folding it into `refreshTick` would have been a shorter diff, but it would also spin the header cat every half hour and re-invoke `refresh_graph`, duplicating the rebuild the backend loop already runs.

Cost is at most four upstream calls per 30 minutes, each already gated on that client being configured.

## Alternative considered

Driving this from Rust inside `spawn_refresh_loop` and emitting an `agent-usage-update` event for `useAgentUsage` to listen on, the way `useGraphStream` consumes `graph-update`. That's the better architectural fit and keeps the cadence defined in one place, but it's a much larger diff and needs a guard so the mount-time invoke and the loop don't double-fetch. Happy to redo it that way if you'd rather the cadence live in the backend.

## Not in this PR

Re-fetching on `popover-shown` behind a short TTL, so opening the dashboard shows current numbers rather than up-to-30-minute-old ones. That's a UX call rather than a bug fix, so I left it out — say the word if you want it folded in.

## Tests

Verified against the dev server (`npm run dev`), which drives the same hook through `/api/agent-usage`, with the interval temporarily set to 3s and network traffic captured in DevTools:

- Before (`main`): 1 × `/api/agent-usage` for the entire session, no matter how long the page stayed open.
- After: repeated `/api/agent-usage` on the interval, while `/api/rate` and `/api/stream` were still fetched exactly once — so nothing else re-fetches as collateral.

Interval restored to 30 minutes before committing. `tsc --noEmit` and `npm run build` clean. No Rust changes, so no `cargo` runs.
