### PR TITLE
Run cargo test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,7 @@ jobs:
       - name: cargo check
         working-directory: src-tauri
         run: cargo check --locked
+
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test --locked


### PR DESCRIPTION
The Rust job runs `cargo check` and stops there, so the unit tests in `agent_usage` never run on a pull request. That's 52 tests covering the Codex, Claude, Grok and Cursor response parsers — exactly the code most likely to break silently when an upstream changes a field name. A regression there compiles cleanly and merges.

Same job, same `Swatinem/rust-cache` workspace, same `--locked` flag as the check above it, so the added wall-clock is just the test link and run.

Verified locally with the exact CI invocation (`cargo test --locked` in `src-tauri`): 52 passed.

Split out of #45 deliberately — that PR adds four tests to this module and would otherwise be landing the tests and the thing that runs them in one diff.