### PR TITLE
Fix minisign signing in the native release workflow

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -132,16 +132,14 @@ jobs:
           # The Tauri CLI signer works standalone — no Tauri project needed.
           # Same key as every 0.1.x release; old clients verify against the
           # pubkey baked into their tauri.conf.json.
-          KEYFILE="$(mktemp)"
-          printf '%s' "$TAURI_SIGNING_PRIVATE_KEY" > "$KEYFILE"
-          # -p is always passed (empty string for an unencrypted key):
-          # omitting it makes the signer prompt on a TTY-less runner and
-          # hang the job. CLI pinned to the version package.json uses.
+          #
+          # Key/password come from the TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)
+          # env vars the CLI reads on its own — the exact mechanism every
+          # 0.1.x `tauri build` release used. Passing -f/-p as well makes
+          # the CLI abort with "--private-key-path cannot be used with
+          # --private-key" (v0.2.0 first run failed on this).
           npx --yes @tauri-apps/cli@2.11.0 signer sign \
-            -f "$KEYFILE" \
-            -p "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
             "Tokcat_${VERSION}_universal.app.tar.gz"
-          rm -f "$KEYFILE"
           test -s "Tokcat_${VERSION}_universal.app.tar.gz.sig"
 
       - name: Sparkle EdDSA signature

--- a/scripts/release-native.sh
+++ b/scripts/release-native.sh
@@ -67,9 +67,14 @@ shasum -a 256 "$OUT/Tokcat_${VERSION}_universal.dmg" | awk '{print $1}' \
   > "$OUT/Tokcat_${VERSION}_universal.dmg.sha256"
 
 echo "==> Sign (minisign, legacy Tauri channel)"
-npx --yes @tauri-apps/cli@2.11.0 signer sign -f "$TAURI_KEY" \
-  -p "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
-  "$OUT/$ASSET"
+# The CLI auto-reads TAURI_SIGNING_PRIVATE_KEY from the env and refuses -f
+# alongside it; feed the key through the env var in both cases.
+if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+  TAURI_SIGNING_PRIVATE_KEY="$(cat "$TAURI_KEY")"
+  export TAURI_SIGNING_PRIVATE_KEY
+fi
+export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}"
+npx --yes @tauri-apps/cli@2.11.0 signer sign "$OUT/$ASSET"
 test -s "$OUT/$ASSET.sig"
 
 echo "==> Sign (Sparkle EdDSA)"


### PR DESCRIPTION
First v0.2.0 run failed: the Tauri CLI auto-reads TAURI_SIGNING_PRIVATE_KEY from the env and refuses an -f flag alongside it. Sign env-only, the same mechanism every 0.1.x release used. No release was published by the failed run; the tag will be re-pointed after merge.