### PR TITLE
Fix tray panel appearing at the left edge on notched MacBooks

### DIFF
--- a/native/LocalPackage/Sources/Model/AppShell/TrayPanelController.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/TrayPanelController.swift
@@ -10,6 +10,9 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
     private static let minHeight: CGFloat = 420
     private static let maxHeight: CGFloat = 1200
     private static let gapBelowStatusItem: CGFloat = 6
+    // tray.rs constants: MENU_BAR_H / POPOVER_SCREEN_MARGIN.
+    private static let menuBarHeight: CGFloat = 24
+    private static let screenMargin: CGFloat = 8
 
     private let panel: TrayPanel
     private let effectView: NSVisualEffectView
@@ -78,7 +81,10 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
     public func setContentHeight(_ height: CGFloat) {
         reportedContentHeight = height
         guard panel.isVisible else { return }
-        applyFrame(topAnchoredAt: panel.frame.maxY)
+        // Resize on the screen the panel is actually on — after the
+        // hidden-status-item fallback the anchor button's screen is
+        // unrelated to where the panel was placed.
+        applyFrame(topAnchoredAt: panel.frame.maxY, on: panel.screen)
     }
 
     // MARK: - Show / hide
@@ -94,10 +100,55 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
         let buttonFrame = anchorWindow.convertToScreen(
             anchor.convert(anchor.bounds, to: nil)
         )
-        let top = buttonFrame.minY - Self.gapBelowStatusItem
-        let centerX = buttonFrame.midX
-        applyFrame(topAnchoredAt: top, centerX: centerX)
+        if let screen = Self.menuBarScreen(containing: buttonFrame) {
+            let top = buttonFrame.minY - Self.gapBelowStatusItem
+            applyFrame(topAnchoredAt: top, centerX: buttonFrame.midX, on: screen)
+        } else {
+            // Status item hidden or unresolvable — a crowded menu bar or
+            // notch overflow parks its window off-screen (or at a bogus
+            // origin like x≈0, which used to drop the panel at the LEFT
+            // edge on notched MacBooks). Mirror tray.rs: dock at the main
+            // display's menu-bar right corner so the panel is always
+            // visible and menu-bar-anchored.
+            let screen = NSScreen.screens.first ?? NSScreen.main
+            let visible = screen?.visibleFrame
+                ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+            applyFrame(
+                topAnchoredAt: visible.maxY - Self.gapBelowStatusItem,
+                centerX: visible.maxX - Self.screenMargin - Self.panelWidth / 2,
+                on: screen)
+        }
         panel.makeKeyAndOrderFront(nil)
+    }
+
+    /// The screen whose menu-bar band actually contains the status-item
+    /// frame (port of tray.rs's tray_anchor resolution). A hidden or
+    /// overflowed item reports coordinates outside every screen's band and
+    /// yields nil. Ambiguities in overlapping layouts resolve to the screen
+    /// where the frame sits closest to the top, like the Rust min_by.
+    private static func menuBarScreen(containing rect: NSRect) -> NSScreen? {
+        let frames = NSScreen.screens.map(\.frame)
+        guard let idx = Self.menuBarScreenIndex(for: rect, screenFrames: frames)
+        else { return nil }
+        return NSScreen.screens[idx]
+    }
+
+    /// Pure core of the anchor resolution, separated for tests: returns the
+    /// index of the screen frame whose menu-bar band contains the rect.
+    static func menuBarScreenIndex(for rect: NSRect,
+                                   screenFrames: [NSRect]) -> Int? {
+        guard rect.width > 0.5 else { return nil }
+        var best: (belowTop: CGFloat, index: Int)?
+        for (index, f) in screenFrames.enumerated() {
+            guard rect.midX >= f.minX, rect.midX < f.maxX else { continue }
+            // Cocoa Y is bottom-up: distance below the screen's top edge.
+            let belowTop = f.maxY - rect.maxY
+            guard (-4.0...(Self.menuBarHeight * 2)).contains(belowTop) else { continue }
+            if best == nil || belowTop < best!.belowTop {
+                best = (belowTop, index)
+            }
+        }
+        return best?.index
     }
 
     public func hide() {
@@ -131,8 +182,13 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
 
     // MARK: - Layout
 
-    private func applyFrame(topAnchoredAt top: CGFloat, centerX: CGFloat? = nil) {
-        let screen = anchorButton?.window?.screen
+    private func applyFrame(topAnchoredAt top: CGFloat, centerX: CGFloat? = nil,
+                            on resolvedScreen: NSScreen? = nil) {
+        // The resolved anchor screen wins: a hidden status item's window
+        // reports a screen that has nothing to do with where the panel
+        // should appear.
+        let screen = resolvedScreen
+            ?? anchorButton?.window?.screen
             ?? panel.screen
             ?? NSScreen.main
         let visible = screen?.visibleFrame

--- a/native/LocalPackage/Tests/ModelTests/PanelAnchorTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/PanelAnchorTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import Model
+
+// Port of tray.rs's tray-anchor resolution semantics: a status-item frame
+// only anchors the panel when it sits inside some screen's menu-bar band;
+// hidden/overflowed items (parked off-screen by AppKit — the notch-MacBook
+// left-edge bug) must resolve to nil so show() takes the top-right fallback.
+@MainActor
+@Suite struct PanelAnchorTests {
+    // 2560×1440 primary + notched 1512×982 laptop to its left.
+    private let primary = NSRect(x: 0, y: 0, width: 2560, height: 1440)
+    private let laptop = NSRect(x: -1512, y: -458, width: 1512, height: 982)
+    private var frames: [NSRect] { [primary, laptop] }
+
+    private func item(x: CGFloat, topInset: CGFloat, on screen: NSRect) -> NSRect {
+        NSRect(x: x, y: screen.maxY - topInset - 22, width: 30, height: 22)
+    }
+
+    @Test func itemInPrimaryMenuBarResolves() {
+        let rect = item(x: 2300, topInset: 1, on: primary)
+        #expect(TrayPanelController.menuBarScreenIndex(for: rect, screenFrames: frames) == 0)
+    }
+
+    @Test func itemInLaptopMenuBarResolvesToLaptop() {
+        let rect = item(x: -300, topInset: 8, on: laptop)  // taller notch menu bar
+        #expect(TrayPanelController.menuBarScreenIndex(for: rect, screenFrames: frames) == 1)
+    }
+
+    @Test func offscreenParkedItemResolvesNil() {
+        // AppKit parks hidden/overflowed status items far off-screen.
+        let rect = NSRect(x: -8000, y: 10_000, width: 30, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: rect, screenFrames: frames) == nil)
+    }
+
+    @Test func midScreenRectResolvesNil() {
+        // In a screen's x-range but nowhere near the menu-bar band.
+        let rect = NSRect(x: 1200, y: 700, width: 30, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: rect, screenFrames: frames) == nil)
+    }
+
+    @Test func zeroWidthRectResolvesNil() {
+        let rect = NSRect(x: 2300, y: primary.maxY - 23, width: 0, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: rect, screenFrames: frames) == nil)
+    }
+
+    @Test func bandToleranceMatchesRust() {
+        // -4pt above the top edge and 2×24pt below are still in the band
+        // (tray.rs: (-4.0..=MENU_BAR_H * 2).contains(below_top)).
+        let slightlyAbove = NSRect(x: 100, y: primary.maxY - 22 + 4, width: 30, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: slightlyAbove, screenFrames: frames) == 0)
+        let deep = NSRect(x: 100, y: primary.maxY - 22 - 48, width: 30, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: deep, screenFrames: frames) == 0)
+        let tooDeep = NSRect(x: 100, y: primary.maxY - 22 - 49, width: 30, height: 22)
+        #expect(TrayPanelController.menuBarScreenIndex(for: tooDeep, screenFrames: frames) == nil)
+    }
+}

--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.0
-        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.2.1
+        CURRENT_PROJECT_VERSION: 2
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Hidden/overflowed status items (notch + crowded menu bar) report bogus window coordinates; the panel centered under them and clamped to the screen's left edge. Ports tray.rs's menu-bar-band anchor validation + primary-display top-right fallback, with unit tests for the resolution core. Verified live on a notched setup. Bumps to 0.2.1/build 2 for the forward-fix release.