### PR TITLE
Restore the Check-for-updates button in Settings

### DIFF
--- a/native/LocalPackage/Sources/UserInterface/Views/SettingsSheet.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/SettingsSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct SettingsSheet: View {
     @EnvironmentObject private var store: DashboardStore
     @EnvironmentObject private var quotaStore: QuotaStore
+    @EnvironmentObject private var updates: UpdateService
     @Environment(\.colorScheme) private var colorScheme
 
     /// Serializes the Cursor-usage opt-in fetch (the toggle is disabled
@@ -291,6 +292,25 @@ struct SettingsSheet: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
+            Divider().padding(.horizontal, 10)
+            // SettingsPanel.tsx parity: the manual update check lives here
+            // as well as in the tray menu / ⌘U. Automatic checks run on
+            // launch + hourly regardless (Sparkle).
+            Button {
+                updates.checkForUpdates()
+            } label: {
+                HStack {
+                    Text("Check for updates…")
+                        .font(.system(size: 12))
+                    Spacer()
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!updates.canCheckForUpdates)
+            .opacity(updates.canCheckForUpdates ? 1 : 0.5)
         }
     }
 

--- a/native/Tokcat/TokcatApp.swift
+++ b/native/Tokcat/TokcatApp.swift
@@ -52,6 +52,7 @@ final class AppMain {
                     .environmentObject(store)
                     .environmentObject(liveTrace)
                     .environmentObject(quota)
+                    .environmentObject(updates)
                     .onPreferenceChange(ContentHeightKey.self) { height in
                         onHeightChange(height)
                     }

--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.2
-        CURRENT_PROJECT_VERSION: 3
+        MARKETING_VERSION: 0.2.3
+        CURRENT_PROJECT_VERSION: 4
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Dropped during the port (updater landed later, button never returned). Automatic Sparkle checks were unaffected; this restores the Settings entry point next to the version row. 0.2.3/build 4.