### PR TITLE
Fix the menu-bar item position reset and the wrapping tooltip

### DIFF
--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
@@ -18,6 +18,12 @@ public final class StatusItemController: NSObject {
     private static let iconPointSize: CGFloat = 18
     private static let iconXOffset: CGFloat = 8
 
+    // Where macOS stores the item's spot, and the copy of the value we last
+    // wrote there ourselves (so a user drag is distinguishable from it).
+    private static let positionKey = "NSStatusItem Preferred Position Item-0"
+    private static let seededPositionKey = "TokcatSeededStatusItemPosition"
+    private static let fallbackPosition = 200.0
+
     private var statusItem: NSStatusItem
     private let runner = RunnerLayer()
     private var currentStyle: AnimationStyle?
@@ -27,6 +33,7 @@ public final class StatusItemController: NSObject {
     private var screenObserver: (any NSObjectProtocol)?
     private var hiddenChecks = 0
     private var lastRecoveryAt = Date.distantPast
+    private var preservedUserPosition = false
 
     public var onLeftClick: (() -> Void)?
     public var menuProvider: (() -> NSMenu)?
@@ -83,10 +90,17 @@ public final class StatusItemController: NSObject {
     // recovery is: detect the parked state, drop the stored position, and
     // rebuild the item (reusing the runner layer + stored title/state).
 
+    // Parked means the item's window sits outside every screen. Occlusion is
+    // NOT a usable signal here: the menu bar legitimately disappears in
+    // fullscreen and under auto-hide, and treating that as parked rebuilt the
+    // item during normal use — which reset the position the user had dragged
+    // it to.
     private var isEffectivelyHidden: Bool {
         guard let window = statusItem.button?.window else { return true }
         if window.screen == nil { return true }
-        return !window.occlusionState.contains(.visible)
+        let frame = window.frame
+        guard frame.width > 0, frame.height > 0 else { return true }
+        return !NSScreen.screens.contains { $0.frame.intersects(frame) }
     }
 
     private func startVisibilityWatch() {
@@ -129,17 +143,29 @@ public final class StatusItemController: NSObject {
         appearanceObservation = nil
         runner.removeFromSuperlayer()
         NSStatusBar.system.removeStatusItem(statusItem)
-        // Re-seat the stored position near the RIGHT edge (the value is the
-        // distance from the right). Removing the preference doesn't help: a
-        // brand-new item is inserted at the LEFT end of the status area,
-        // which on a crowded bar is exactly the hidden zone it just died
-        // in (verified empirically). A small offset lands it beside the
-        // system items, in the always-visible region.
-        UserDefaults.standard.set(
-            200.0, forKey: "NSStatusItem Preferred Position Item-0")
+        reseatPositionIfNeeded()
         statusItem = NSStatusBar.system.statusItem(
             withLength: NSStatusItem.variableLength)
         configureItem()
+    }
+
+    // The fallback value is the distance from the RIGHT edge. Removing the
+    // preference doesn't help: a brand-new item is inserted at the LEFT end of
+    // the status area, which on a crowded bar is exactly the hidden zone it
+    // just died in (verified empirically). A small offset lands it beside the
+    // system items, in the always-visible region. See StatusItemPlacement for
+    // when the stored position is left alone instead.
+    private func reseatPositionIfNeeded() {
+        let defaults = UserDefaults.standard
+        let decision = StatusItemPlacement.decide(
+            stored: defaults.object(forKey: Self.positionKey) as? Double,
+            seeded: defaults.object(forKey: Self.seededPositionKey) as? Double,
+            alreadyPreserved: preservedUserPosition,
+            fallback: Self.fallbackPosition)
+        preservedUserPosition = decision.preservedUserPosition
+        guard let seatAt = decision.seatAt else { return }
+        defaults.set(seatAt, forKey: Self.positionKey)
+        defaults.set(seatAt, forKey: Self.seededPositionKey)
     }
 
     private var diagTimer: Timer?

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// Where a rebuilt status item should sit. Split out of StatusItemController
+// (and kept free of AppKit) so the rule has direct test coverage.
+//
+// macOS stores the item's spot in "NSStatusItem Preferred Position Item-0" —
+// the same preference it rewrites when the user Cmd-drags the item. Hidden-item
+// recovery used to overwrite that value on every rebuild, which yanked the item
+// back out of wherever the user had put it. So: only reseat a value we wrote
+// ourselves. If preserving the user's choice didn't bring the item back, the
+// stored position is itself the problem and the fallback slot wins.
+public enum StatusItemPlacement {
+    public struct Decision: Equatable {
+        // The position to write, or nil to leave the stored one untouched.
+        public let seatAt: Double?
+        // Carried back into the next decision.
+        public let preservedUserPosition: Bool
+    }
+
+    public static func decide(
+        stored: Double?,
+        seeded: Double?,
+        alreadyPreserved: Bool,
+        fallback: Double
+    ) -> Decision {
+        let userMoved = stored != nil && stored != seeded
+        if userMoved, !alreadyPreserved {
+            return Decision(seatAt: nil, preservedUserPosition: true)
+        }
+        return Decision(seatAt: fallback, preservedUserPosition: false)
+    }
+}

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -204,12 +204,16 @@ struct UsageBarChart: View {
         VStack(alignment: .leading, spacing: 5) {
             Text(Formatters.formatMonthDay(bar.date))
                 .font(.system(size: 11, weight: .semibold))
-            HStack(spacing: 10) {
+            HStack(spacing: 8) {
                 Text("\(NumberText.exactTokens(bar.totalTokens)) tokens")
-                Spacer(minLength: 8)
+                    .layoutPriority(1)
+                Spacer(minLength: 4)
                 Text(Formatters.formatCost(bar.totalCost))
+                    .fixedSize()
             }
             .font(.system(size: 11, weight: .medium))
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
             Divider()
             ForEach(bar.segments) { segment in
                 let style = ClientRegistry.style(for: segment.clientId)
@@ -223,6 +227,8 @@ struct UsageBarChart: View {
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)
                 }
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
             }
         }
         .padding(8)

--- a/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+
+@testable import Model
+
+// Hidden-item recovery rebuilds the status item, and the rebuild used to
+// overwrite "NSStatusItem Preferred Position Item-0" unconditionally — the
+// same preference macOS rewrites when the user Cmd-drags the item. The item
+// therefore jumped back into the system-item zone every time the user moved
+// it. These pin the rule that fixed it.
+@Suite struct StatusItemPlacementTests {
+    private let fallback = 200.0
+
+    private func decide(
+        stored: Double?, seeded: Double?, alreadyPreserved: Bool = false
+    ) -> StatusItemPlacement.Decision {
+        StatusItemPlacement.decide(
+            stored: stored, seeded: seeded,
+            alreadyPreserved: alreadyPreserved, fallback: fallback)
+    }
+
+    @Test func keepsAPositionTheUserDraggedTo() {
+        let d = decide(stored: 500, seeded: fallback)
+        #expect(d.seatAt == nil)
+        #expect(d.preservedUserPosition)
+    }
+
+    @Test func reseatsAPositionWeWroteOurselves() {
+        let d = decide(stored: fallback, seeded: fallback)
+        #expect(d.seatAt == fallback)
+        #expect(!d.preservedUserPosition)
+    }
+
+    @Test func seatsWhenNoPositionIsStored() {
+        let d = decide(stored: nil, seeded: nil)
+        #expect(d.seatAt == fallback)
+    }
+
+    // Preserving the user's spot once is a courtesy, not a trap: if the item
+    // is still parked on the next pass, that stored position is the problem.
+    @Test func fallsBackWhenPreservingDidNotRecoverTheItem() {
+        let first = decide(stored: 3000, seeded: fallback)
+        #expect(first.seatAt == nil)
+        let second = decide(
+            stored: 3000, seeded: fallback,
+            alreadyPreserved: first.preservedUserPosition)
+        #expect(second.seatAt == fallback)
+        #expect(!second.preservedUserPosition)
+    }
+}


### PR DESCRIPTION
Two menu-bar annoyances, both reported from the same screenshot pass.

### The tooltip wrapped `tokens` onto its own line

The chart tooltip is a fixed 190pt wide, so a nine-digit day (225,363,034) pushed `tokens` to a second line. The header and the per-client rows are now held to one line, scaling down slightly on the widest days.

### The status item kept jumping back among the system items

Hidden-item recovery (#50) rebuilt the item and rewrote `NSStatusItem Preferred Position Item-0` to a fixed 200pt-from-the-right slot. That slot sits in the middle of the system items (한 / wifi / Siri), and it is the same preference macOS rewrites when the user Cmd-drags the item — so any spot the user picked was undone on the next rebuild.

Two causes:

- Parked detection used `occlusionState`, so a menu bar hidden for ordinary reasons (fullscreen, auto-hide) counted as parked and rebuilt the item during normal use. It now tests the item's window against the screen frames, which is what "parked off-screen" actually means.
- The reseat is now conditional: only a position we wrote ourselves gets overwritten, tracked in our own key. If preserving the user's position doesn't bring the item back, the next pass falls back to the known-good slot, so a genuinely bad stored position still recovers.

The placement rule is split into `StatusItemPlacement` so it is unit-tested rather than only reachable through AppKit.

### Verification

`swift build` + `swift test` (140 tests, 4 new). E2E against a local Debug build of the app bundle:

| Scenario | Result |
| --- | --- |
| Seeded a parked position (3000), launched | Detected after ~31s, rebuilt once, reseated to 200, item visible — recovery still works |
| Simulated a user drag (stored 500, our seed 200) | Position held at 500 for 135s with 0 rebuilds; item sits left of the system items |
| Tooltip on a 10-digit day (2,036,331,110 tokens) | Single line, cost still right-aligned |