### PR TITLE
Release Tokcat 0.2.4

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.3
-        CURRENT_PROJECT_VERSION: 4
+        MARKETING_VERSION: 0.2.4
+        CURRENT_PROJECT_VERSION: 5
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump only — `MARKETING_VERSION` 0.2.3 → 0.2.4, `CURRENT_PROJECT_VERSION` 4 → 5 (the published appcast's `sparkle:version` is 4, so Sparkle clients need 5 to see this).

Ships the two fixes already on main from #52:
- The chart tooltip no longer wraps `tokens` onto a second line on nine-digit days.
- Hidden-item recovery no longer overwrites a menu-bar position the user dragged the item to.