### PR TITLE
fix(claude): stop redeeming the Claude refresh token, which could log Claude Code out

### DIFF
--- a/native/LocalPackage/Sources/Collector/Quota/ClaudeProvider.swift
+++ b/native/LocalPackage/Sources/Collector/Quota/ClaudeProvider.swift
@@ -3,15 +3,29 @@ import Foundation
 
 // Port of the Claude OAuth quota provider in agent_usage.rs
 // (:659-742, 786-863, 957-995, 1057-1100, 1192-1315, 2209-2236).
+//
+// One deliberate divergence from that port: the Rust code refreshed an expired
+// Claude access token, and this no longer does. See `ClaudeCredentials` (#55).
 
 private let claudeUsageURL = "https://api.anthropic.com/api/oauth/usage"
-private let claudeRefreshURL = "https://platform.claude.com/v1/oauth/token"
-private let claudeClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 private let claudeKeychainService = "Claude Code-credentials"
 
+/// Tokcat reads the Claude credential but never renews it.
+///
+/// Redeeming the refresh token rotates it server-side, and Tokcat has no way
+/// to write the replacement back: the credential lives in the login Keychain,
+/// which Claude Code owns and updates under its own locking. A refresh here
+/// would leave the stored credential pointing at a token that has already been
+/// spent, and the next refresh Claude Code performs would be rejected —
+/// silently logging the user out (#55).
+///
+/// So `refreshToken` is deliberately absent from this type. An expired access
+/// token is surfaced as an error telling the user to run `claude`, which is the
+/// process that owns the token lifecycle. Codex is different (its credential is
+/// a plain file this app can rewrite), which is why `CodexProvider` refreshes
+/// and `saveCodexCredentials` persists.
 struct ClaudeCredentials {
     var accessToken: String
-    var refreshToken: String?
     var expiresAt: Date?
     var scopes: [String]
     var rateLimitTier: String?
@@ -198,15 +212,8 @@ public enum ClaudeQuotaProvider {
     }
 
     static func fetchInner() async throws -> AgentUsageSnapshot {
-        var credentials = try loadClaudeCredentials()
-        if claudeCredentialsExpired(credentials) {
-            credentials = try await refreshClaudeCredentials(credentials)
-        }
-
-        if !credentials.scopes.isEmpty && !credentials.scopes.contains("user:profile") {
-            throw QuotaError(
-                "Claude OAuth token lacks the user:profile scope. Run `claude logout && claude login`.")
-        }
+        let credentials = try loadClaudeCredentials()
+        try validateCredentials(credentials)
 
         var request = URLRequest(url: URL(string: claudeUsageURL)!)
         request.timeoutInterval = 30
@@ -317,7 +324,7 @@ public enum ClaudeQuotaProvider {
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
         return ClaudeCredentials(
-            accessToken: accessToken, refreshToken: nil, expiresAt: nil,
+            accessToken: accessToken, expiresAt: nil,
             scopes: scopes, rateLimitTier: nil, subscriptionType: nil)
     }
 
@@ -382,11 +389,10 @@ public enum ClaudeQuotaProvider {
         } else {
             scopes = []
         }
+        // `refreshToken` is intentionally not read out of the blob: nothing in
+        // this app may redeem it. See the note on `ClaudeCredentials`.
         return ClaudeCredentials(
             accessToken: accessToken,
-            refreshToken: oauth["refreshToken"]?.asString
-                .map { $0.trimmingCharacters(in: .whitespaces) }
-                .flatMap { $0.isEmpty ? nil : $0 },
             expiresAt: expiresAt,
             scopes: scopes,
             rateLimitTier: oauth["rateLimitTier"]?.asString,
@@ -399,50 +405,22 @@ public enum ClaudeQuotaProvider {
         return now >= expiresAt
     }
 
-    /// Refreshed credentials are NOT persisted (mirror: the Rust code never
-    /// writes Claude credentials back anywhere).
-    static func refreshClaudeCredentials(
-        _ credentials: ClaudeCredentials
-    ) async throws -> ClaudeCredentials {
-        guard let refreshToken = credentials.refreshToken else {
+    /// Checks that run before the usage request. Split out of `fetchInner` so
+    /// they are testable without a network round-trip.
+    ///
+    /// An expired token is reported rather than renewed — see the note on
+    /// `ClaudeCredentials`. `claude` is the process that owns the refresh, so
+    /// pointing the user at it is both the fix and the only safe action.
+    static func validateCredentials(_ credentials: ClaudeCredentials,
+                                    now: Date = Date()) throws {
+        if claudeCredentialsExpired(credentials, now: now) {
             throw QuotaError(
-                "Claude OAuth token is expired and has no refresh token. Run `claude`.")
+                "Claude access token expired. Run `claude` to refresh it.")
         }
-        var request = URLRequest(url: URL(string: claudeRefreshURL)!)
-        request.timeoutInterval = 30
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: [
-            "grant_type": "refresh_token",
-            "refresh_token": refreshToken,
-            "client_id": claudeClientID,
-        ])
-
-        let status: Int
-        let body: Data
-        do {
-            (status, body) = try await QuotaHTTP.send(request)
-        } catch {
-            throw QuotaError("Claude OAuth refresh failed: \(error.localizedDescription)")
+        if !credentials.scopes.isEmpty && !credentials.scopes.contains("user:profile") {
+            throw QuotaError(
+                "Claude OAuth token lacks the user:profile scope. Run `claude logout && claude login`.")
         }
-        if !(200..<300).contains(status) {
-            throw QuotaError("Claude OAuth refresh failed. Run `claude` to re-authenticate.")
-        }
-        guard
-            let json = JSONValue.parse(body),
-            let accessToken = json["access_token"]?.asString,
-            let expiresIn = json["expires_in"]?.asInt64
-        else {
-            throw QuotaError("decode Claude refresh response: missing fields")
-        }
-        return ClaudeCredentials(
-            accessToken: accessToken,
-            refreshToken: json["refresh_token"]?.asString ?? credentials.refreshToken,
-            expiresAt: Date().addingTimeInterval(TimeInterval(expiresIn)),
-            scopes: credentials.scopes,
-            rateLimitTier: credentials.rateLimitTier,
-            subscriptionType: credentials.subscriptionType)
     }
 
     /// `claude_user_agent`: `claude --version` through the subprocess guard,

--- a/native/LocalPackage/Sources/Model/Stores/QuotaStore.swift
+++ b/native/LocalPackage/Sources/Model/Stores/QuotaStore.swift
@@ -37,6 +37,17 @@ public final class QuotaStore: ObservableObject {
     @Published public private(set) var cursorUsageError: String?
 
     private var autoRefreshTask: Task<Void, Never>?
+    /// Set when the user asks for a refresh while one is already running.
+    /// Drained by `refresh()` rather than starting a second concurrent pass,
+    /// so repeated presses collapse into a single extra fetch.
+    var pendingUserRefresh = false
+
+    /// The provider fan-out, injectable so the refresh state machine can be
+    /// tested without four upstream calls. Production never replaces it; it
+    /// is not public, so nothing outside this module can.
+    var runProviders: @Sendable () async -> AgentUsagePayload = {
+        await AgentQuota.run()
+    }
 
     public init() {}
 
@@ -70,17 +81,49 @@ public final class QuotaStore: ObservableObject {
     // MARK: - Refresh
 
     /// Run the four providers concurrently off-main and publish the result.
+    ///
+    /// Best-effort: a call while a fetch is in flight is dropped, which is
+    /// what the automatic callers want. Use `refreshNow()` for a press the
+    /// user is waiting on.
     public func refresh() {
         guard !isRefreshing else { return }
         isRefreshing = true
+        let run = runProviders
         Task { [weak self] in
-            let payload = await Task.detached(priority: .utility) {
-                await AgentQuota.run()
-            }.value
-            guard let self else { return }
-            self.apply(payload)
-            self.isRefreshing = false
+            while true {
+                let payload = await Task.detached(priority: .utility) {
+                    await run()
+                }.value
+                guard let self else { return }
+                self.apply(payload)
+                // A press that landed mid-fetch was answered with a payload
+                // gathered before it, so run once more rather than reporting
+                // the stale result as the response to it. isRefreshing stays
+                // true across the hand-off, so the spinner does not blink.
+                if self.pendingUserRefresh {
+                    self.pendingUserRefresh = false
+                    continue
+                }
+                self.isRefreshing = false
+                return
+            }
         }
+    }
+
+    /// Refresh on explicit user action — the header button, the Refresh Now
+    /// menu item, and ⌘R.
+    ///
+    /// Never dropped, unlike `refresh()`. An in-flight fetch may have read
+    /// its credentials before the user fixed them (running `claude` after an
+    /// expired-token error is exactly this case), so answering the press with
+    /// that fetch's result would strand the error on screen until the next
+    /// 30-minute tick.
+    public func refreshNow() {
+        guard isRefreshing else {
+            refresh()
+            return
+        }
+        pendingUserRefresh = true
     }
 
     /// Popover-open top-up: only re-fetch when the snapshot is older than

--- a/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
@@ -20,10 +20,18 @@ private enum BrandLogo {
 // select is a subtle gray chip (.theme-select) — neither shows a native bezel.
 struct HeaderBar: View {
     @EnvironmentObject private var store: DashboardStore
+    @EnvironmentObject private var quotaStore: QuotaStore
     @ObservedObject private var keys = CmdHeldObserver.shared
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var spinStartedAt: Date?
+
+    /// The button drives both stores, so it has to keep spinning until the
+    /// slower one lands — quota is the slower one (upstream calls plus
+    /// subprocess spawns) and is usually why the user pressed Refresh.
+    private var isRefreshing: Bool {
+        store.isRefreshing || quotaStore.isRefreshing
+    }
 
     private var mode: ThemeMode {
         Themes.theme(named: store.themeName).mode(for: colorScheme)
@@ -56,6 +64,10 @@ struct HeaderBar: View {
 
             Button {
                 store.refresh()
+                // Quota too: an expired Claude token is only cleared by
+                // running `claude`, and Refresh is how the user asks for
+                // that to be picked up rather than waiting out the timer.
+                quotaStore.refresh()
             } label: {
                 // Time-driven continuous spin (like the CSS .refresh-spin
                 // keyframes): a state-animated repeatForever spun up with a
@@ -79,7 +91,7 @@ struct HeaderBar: View {
             .buttonStyle(.borderless)
             .help("Refresh")
             .kbdPin("⌘R", visible: keys.cmdHeld)
-            .onChange(of: store.isRefreshing) { refreshing in
+            .onChange(of: isRefreshing) { refreshing in
                 spinStartedAt = refreshing ? Date() : nil
             }
 

--- a/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
@@ -67,7 +67,7 @@ struct HeaderBar: View {
                 // Quota too: an expired Claude token is only cleared by
                 // running `claude`, and Refresh is how the user asks for
                 // that to be picked up rather than waiting out the timer.
-                quotaStore.refresh()
+                quotaStore.refreshNow()
             } label: {
                 // Time-driven continuous spin (like the CSS .refresh-spin
                 // keyframes): a state-animated repeatForever spun up with a

--- a/native/LocalPackage/Tests/CollectorTests/QuotaClaudeTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/QuotaClaudeTests.swift
@@ -25,9 +25,10 @@ private func date(_ epochSeconds: Int64) -> Date {
                 }
             }
             """
+        // A blob carrying a refreshToken still parses; the token itself is not
+        // lifted into ClaudeCredentials, which has no field for it (#55).
         let credentials = try ClaudeQuotaProvider.parseClaudeCredentialsData(raw)
         #expect(credentials.accessToken == "access")
-        #expect(credentials.refreshToken == "refresh")
         #expect(credentials.scopes == ["user:profile"])
         #expect(credentials.subscriptionType == "pro")
         #expect(credentials.expiresAt == date(1_700_000_000))
@@ -45,7 +46,7 @@ private func date(_ epochSeconds: Int64) -> Date {
 
     @Test func expiryComparesAgainstNow() {
         let credentials = ClaudeCredentials(
-            accessToken: "a", refreshToken: nil,
+            accessToken: "a",
             expiresAt: date(1_700_000_000), scopes: [],
             rateLimitTier: nil, subscriptionType: nil)
         #expect(ClaudeQuotaProvider.claudeCredentialsExpired(
@@ -56,6 +57,49 @@ private func date(_ epochSeconds: Int64) -> Date {
         noExpiry.expiresAt = nil
         #expect(!ClaudeQuotaProvider.claudeCredentialsExpired(
             noExpiry, now: date(1_800_000_000)))
+    }
+
+    /// An expired token must be reported, never renewed: redeeming the refresh
+    /// token rotates it server-side and Tokcat cannot write the replacement
+    /// back into the Keychain, which would log Claude Code out (#55).
+    @Test func expiredCredentialsAreReportedNotRefreshed() {
+        let expired = ClaudeCredentials(
+            accessToken: "a",
+            expiresAt: date(1_700_000_000), scopes: ["user:profile"],
+            rateLimitTier: nil, subscriptionType: nil)
+        #expect(throws: QuotaError.self) {
+            try ClaudeQuotaProvider.validateCredentials(
+                expired, now: date(1_700_000_001))
+        }
+    }
+
+    @Test func validateAcceptsLiveCredentials() throws {
+        let live = ClaudeCredentials(
+            accessToken: "a",
+            expiresAt: date(1_700_000_000), scopes: ["user:profile"],
+            rateLimitTier: nil, subscriptionType: nil)
+        try ClaudeQuotaProvider.validateCredentials(live, now: date(1_699_999_999))
+
+        // No expiry recorded is not treated as expired.
+        var noExpiry = live
+        noExpiry.expiresAt = nil
+        try ClaudeQuotaProvider.validateCredentials(noExpiry, now: date(1_800_000_000))
+
+        // Scopes are only enforced when the credential actually lists them.
+        var noScopes = live
+        noScopes.scopes = []
+        try ClaudeQuotaProvider.validateCredentials(noScopes, now: date(1_699_999_999))
+    }
+
+    @Test func validateRejectsMissingProfileScope() {
+        let credentials = ClaudeCredentials(
+            accessToken: "a",
+            expiresAt: nil, scopes: ["user:inference"],
+            rateLimitTier: nil, subscriptionType: nil)
+        #expect(throws: QuotaError.self) {
+            try ClaudeQuotaProvider.validateCredentials(
+                credentials, now: date(1_700_000_000))
+        }
     }
 
     @Test func mapsOAuthWindows() {

--- a/native/LocalPackage/Tests/CollectorTests/QuotaClaudeTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/QuotaClaudeTests.swift
@@ -62,15 +62,35 @@ private func date(_ epochSeconds: Int64) -> Date {
     /// An expired token must be reported, never renewed: redeeming the refresh
     /// token rotates it server-side and Tokcat cannot write the replacement
     /// back into the Keychain, which would log Claude Code out (#55).
+    ///
+    /// The message is asserted verbatim because it is the whole remedy the
+    /// user gets: it has to send them to `claude` to refresh, and must not
+    /// imply the login is gone and needs re-authenticating.
     @Test func expiredCredentialsAreReportedNotRefreshed() {
         let expired = ClaudeCredentials(
             accessToken: "a",
             expiresAt: date(1_700_000_000), scopes: ["user:profile"],
             rateLimitTier: nil, subscriptionType: nil)
-        #expect(throws: QuotaError.self) {
+        let error = #expect(throws: QuotaError.self) {
             try ClaudeQuotaProvider.validateCredentials(
                 expired, now: date(1_700_000_001))
         }
+        #expect(error?.message == "Claude access token expired. Run `claude` to refresh it.")
+    }
+
+    /// Expiry is checked before scopes, so a credential that is both expired
+    /// and under-scoped reports the expiry — the actionable one, since running
+    /// `claude` is what refreshes it.
+    @Test func expiryIsReportedBeforeScope() {
+        let credentials = ClaudeCredentials(
+            accessToken: "a",
+            expiresAt: date(1_700_000_000), scopes: ["user:inference"],
+            rateLimitTier: nil, subscriptionType: nil)
+        let error = #expect(throws: QuotaError.self) {
+            try ClaudeQuotaProvider.validateCredentials(
+                credentials, now: date(1_700_000_001))
+        }
+        #expect(error?.message == "Claude access token expired. Run `claude` to refresh it.")
     }
 
     @Test func validateAcceptsLiveCredentials() throws {
@@ -96,10 +116,12 @@ private func date(_ epochSeconds: Int64) -> Date {
             accessToken: "a",
             expiresAt: nil, scopes: ["user:inference"],
             rateLimitTier: nil, subscriptionType: nil)
-        #expect(throws: QuotaError.self) {
+        let error = #expect(throws: QuotaError.self) {
             try ClaudeQuotaProvider.validateCredentials(
                 credentials, now: date(1_700_000_000))
         }
+        #expect(error?.message == "Claude OAuth token lacks the user:profile scope. "
+            + "Run `claude logout && claude login`.")
     }
 
     @Test func mapsOAuthWindows() {

--- a/native/LocalPackage/Tests/ModelTests/QuotaStoreRefreshTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/QuotaStoreRefreshTests.swift
@@ -1,0 +1,137 @@
+import DataSource
+import Foundation
+import Testing
+
+@testable import Model
+
+// Refresh state machine of QuotaStore: which calls are allowed to be dropped
+// while a fetch is in flight, and which are not.
+//
+// The distinction matters because an in-flight fetch reads its credentials
+// before it finishes. A user who hits Refresh after fixing an expired Claude
+// token (#55) would otherwise be answered by a fetch that had already read the
+// broken credential, stranding the error until the 30-minute tick.
+
+/// Sequences provider calls without sleeping: each `runProviders` invocation
+/// records itself and hands control back through a payload the test supplies,
+/// so the drain loop is exercised deterministically.
+@MainActor
+private final class ProviderProbe {
+    private(set) var calls = 0
+    /// Runs on the Nth provider call, before it returns — the seam used to
+    /// simulate a button press landing mid-fetch.
+    var onCall: ((Int) -> Void)?
+
+    func payload() -> AgentUsagePayload {
+        calls += 1
+        onCall?(calls)
+        return AgentUsagePayload(
+            generatedAt: "2026-01-01T00:00:0\(min(calls, 9)).000Z", agents: [])
+    }
+}
+
+/// Pumps the main-actor run loop until `condition` holds, without wall-clock
+/// waits. Bounded so a regression fails the test instead of hanging CI.
+@MainActor
+private func settle(
+    until condition: () -> Bool, _ label: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+) async {
+    for _ in 0..<10_000 {
+        if condition() { return }
+        await Task.yield()
+    }
+    Issue.record("timed out waiting for \(label)", sourceLocation: sourceLocation)
+}
+
+@Suite @MainActor struct QuotaStoreRefreshTests {
+    /// The pre-existing contract: automatic callers must not stack fetches.
+    @Test func refreshIsDroppedWhileAFetchIsInFlight() async {
+        let probe = ProviderProbe()
+        let store = QuotaStore()
+        store.runProviders = { await probe.payload() }
+
+        probe.onCall = { call in
+            // A second automatic refresh arriving mid-fetch is discarded.
+            if call == 1 { store.refresh() }
+        }
+        store.refresh()
+
+        await settle(until: { !store.isRefreshing }, "refresh to finish")
+        #expect(probe.calls == 1)
+        #expect(store.pendingUserRefresh == false)
+    }
+
+    /// The fix: an explicit press mid-fetch is queued, not dropped, and the
+    /// store runs the providers a second time to answer it.
+    @Test func refreshNowMidFetchRunsTheProvidersAgain() async {
+        let probe = ProviderProbe()
+        let store = QuotaStore()
+        store.runProviders = { await probe.payload() }
+
+        probe.onCall = { call in
+            if call == 1 {
+                store.refreshNow()
+                #expect(store.pendingUserRefresh)
+            }
+        }
+        store.refresh()
+
+        await settle(until: { !store.isRefreshing }, "queued refresh to finish")
+        #expect(probe.calls == 2)
+        #expect(store.pendingUserRefresh == false)
+    }
+
+    /// Repeated presses during one fetch collapse into a single extra pass —
+    /// the queue is a flag, not a backlog.
+    @Test func repeatedPressesCoalesceIntoOneExtraPass() async {
+        let probe = ProviderProbe()
+        let store = QuotaStore()
+        store.runProviders = { await probe.payload() }
+
+        probe.onCall = { call in
+            if call == 1 {
+                store.refreshNow()
+                store.refreshNow()
+                store.refreshNow()
+            }
+        }
+        store.refresh()
+
+        await settle(until: { !store.isRefreshing }, "coalesced refresh to finish")
+        #expect(probe.calls == 2)
+    }
+
+    /// isRefreshing must stay true across the hand-off, otherwise the header
+    /// spinner blinks between the two passes.
+    @Test func spinnerStaysUpAcrossTheHandOff() async {
+        let probe = ProviderProbe()
+        let store = QuotaStore()
+        store.runProviders = { await probe.payload() }
+
+        probe.onCall = { call in
+            if call == 1 { store.refreshNow() }
+            // True on both passes, including the moment the first one ends
+            // and the queued one takes over.
+            #expect(store.isRefreshing)
+        }
+        store.refresh()
+
+        await settle(until: { !store.isRefreshing }, "hand-off to finish")
+        #expect(probe.calls == 2)
+    }
+
+    /// When nothing is running, refreshNow just starts a fetch.
+    @Test func refreshNowWhenIdleStartsAFetch() async {
+        let probe = ProviderProbe()
+        let store = QuotaStore()
+        store.runProviders = { await probe.payload() }
+
+        store.refreshNow()
+        #expect(store.isRefreshing)
+        #expect(store.pendingUserRefresh == false)
+
+        await settle(until: { !store.isRefreshing }, "idle refreshNow to finish")
+        #expect(probe.calls == 1)
+    }
+}

--- a/native/Tokcat/TokcatApp.swift
+++ b/native/Tokcat/TokcatApp.swift
@@ -76,7 +76,7 @@ final class AppMain {
                     under: delegate.statusItemController?.button)
             case .refreshNow:
                 store.refresh()
-                quota.refresh()
+                quota.refreshNow()
             case .checkForUpdates:
                 updates.checkForUpdates()
             case .openTokcat:
@@ -172,7 +172,7 @@ final class AppMain {
                         return true
                     case "r":
                         store.refresh()
-                        quota.refresh()
+                        quota.refreshNow()
                         return true
                     case "g":
                         store.usageView = store.usageView == "3d" ? "2d" : "3d"

--- a/native/Tokcat/TokcatApp.swift
+++ b/native/Tokcat/TokcatApp.swift
@@ -76,6 +76,7 @@ final class AppMain {
                     under: delegate.statusItemController?.button)
             case .refreshNow:
                 store.refresh()
+                quota.refresh()
             case .checkForUpdates:
                 updates.checkForUpdates()
             case .openTokcat:
@@ -171,6 +172,7 @@ final class AppMain {
                         return true
                     case "r":
                         store.refresh()
+                        quota.refresh()
                         return true
                     case "g":
                         store.usageView = store.usageView == "3d" ? "2d" : "3d"


### PR DESCRIPTION
Fixes #55.

Tokcat could log Claude Code out. The Claude quota provider refreshed an expired access token but never persisted the result — documented in the code as intentional — while the refresh response can carry a **rotated** refresh token that was parsed into a local value and dropped. When the CLI is idle past the access token lifetime, Tokcat polls every 30 minutes and is normally the first party to reach the expired credential, so it redeemed the refresh token, retiring it server-side while the Keychain kept the spent one. The next refresh Claude Code performed could then be rejected, and the user was silently signed out.

Reading usage must not change the authentication state of the tool being monitored.

## Approach

The refresh path is **removed** rather than made to persist. Persisting was the other option, but the Claude credential lives in the login Keychain that Claude Code owns and writes under its own locking — racing that write risks breaking the very login it would be trying to preserve. Codex is deliberately left as it is: its credential is a plain file this app can safely rewrite, which is why `CodexProvider` still refreshes and `saveCodexCredentials` still persists.

The trade-off is that an expired token now surfaces as an error instead of being transparently renewed. That is the point — `claude` owns the token lifecycle, so the error tells the user to run it, and deliberately says *refresh*, not *re-authenticate*, because the login itself is still intact.

## Commits

**1. `fix(claude): stop redeeming the Claude refresh token`**
- Drops `refreshClaudeCredentials` and its endpoint/client-id constants.
- Drops `ClaudeCredentials.refreshToken` and stops lifting it out of the credential blob, so the token cannot be redeemed *by construction* rather than by convention.
- Adds `validateCredentials`, splitting the expiry and scope pre-flight out of `fetchInner` so both are testable without a network round-trip.

**2. `fix(quota): refresh quota on manual Refresh, tighten Claude error tests`**
- Telling the user to run `claude` was useless while no Refresh path could pick the result up: all three user-initiated entry points (header button, Refresh Now menu item, ⌘R) drove `DashboardStore` only, so quota recovery waited out the 5-minute panel staleness check or the 30-minute timer. They now drive `QuotaStore` too.
- `SettingsSheet`'s refresh stays dashboard-only — it is a targeted graph rebuild after the Cursor cache write, not a user Refresh.
- The header spinner tracks both stores, since quota is the slower one and is usually why Refresh was pressed.

**3. `fix(quota): queue an explicit Refresh instead of dropping it mid-fetch`**
- Wiring alone was still not enough: `QuotaStore`'s re-entry guard discards any call arriving while a fetch is in flight, and that fetch may have read its credentials before the user fixed them — so the one press that mattered could still be answered with the stale result.
- `refresh()` keeps dropping, which is what `start()`, the timer and `refreshIfStale()` want; they must not stack four upstream calls plus three subprocess spawns. The new `refreshNow()` records the press, and `refresh()` drains it with one more pass before finishing.
- Repeated presses collapse into a single extra pass, and `isRefreshing` stays true across the hand-off so the spinner does not blink.
- `runProviders` becomes an injectable seam — internal, so no new public API — because the store had no tests at all and the state machine is what carries the risk here.

## Testing

`swift test` in `native/LocalPackage`: **149 tests / 27 suites** pass (143 before).

- `QuotaClaudeTests`: expiry reported rather than renewed, expiry pinned ahead of the scope check, and both rejection messages asserted verbatim — that copy is the entire remedy the user gets, so a wording change should require an intentional test update.
- `QuotaStoreRefreshTests` (new): drop-while-busy (unchanged contract), queue on explicit press, coalescing, spinner continuity, and the idle path. The harness uses no wall-clock sleeps — it pumps the main-actor run loop, bounded, and fails explicitly on timeout rather than hanging.

Both new test groups were run against a reverted fix to confirm they are not vacuous: 3 of the 5 `QuotaStoreRefreshTests` fail without it, and the 2 that still pass are the ones covering pre-existing behavior.

> **Note on the app target:** `native/Tokcat/TokcatApp.swift` is outside the SwiftPM package and I did not have `xcodegen` available, so it was verified with `swiftc -typecheck -parse-as-library` against the built module search path (exit 0, with a negative control confirming the check catches errors) rather than a real `xcodebuild`. Worth a proper build on your side.

## Known cosmetic gap, not addressed

`HeaderBar`'s `.onChange` does not fire for the initial value, so if the header mounts while a quota refresh is already active the spinner is missing for that first pass. It cannot stick or flicker — only fail to appear. Left alone to keep this PR to the auth fix; happy to follow up if you'd rather have it here.
