### PR TITLE
Fix the clipped header and empty band after a tab switch

### DIFF
--- a/native/LocalPackage/Sources/Model/AppShell/TrayPanelController.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/TrayPanelController.swift
@@ -81,10 +81,20 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
     public func setContentHeight(_ height: CGFloat) {
         reportedContentHeight = height
         guard panel.isVisible else { return }
+        // Resize on the NEXT runloop turn, never inside the SwiftUI layout
+        // pass that reported the height: resizing the window mid-pass leaves
+        // the hosting view's scroll view sized from a stale height (it ends
+        // up off by the height delta, applied twice), which is what clipped
+        // the header and left an empty band after a tab switch.
+        //
         // Resize on the screen the panel is actually on — after the
         // hidden-status-item fallback the anchor button's screen is
         // unrelated to where the panel was placed.
-        applyFrame(topAnchoredAt: panel.frame.maxY, on: panel.screen)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.panel.isVisible else { return }
+            self.applyFrame(topAnchoredAt: self.panel.frame.maxY, on: self.panel.screen)
+            self.resetScrollToTop()
+        }
     }
 
     // MARK: - Show / hide
@@ -119,6 +129,35 @@ public final class TrayPanelController: NSObject, NSWindowDelegate {
                 on: screen)
         }
         panel.makeKeyAndOrderFront(nil)
+        resetScrollToTop()
+    }
+
+    /// Reopening the panel must not restore the scroll offset it had when it
+    /// was dismissed: the panel is resized to the content while hidden, so a
+    /// stale offset shows up as a missing header plus an empty band at the
+    /// bottom. Runs on the next pass, after the content has laid out.
+    private func resetScrollToTop() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let scrollView = Self.firstScrollView(in: self.effectView)
+            else { return }
+            let clip = scrollView.contentView
+            let flipped = clip.documentView?.isFlipped ?? true
+            let top = flipped
+                ? 0
+                : (clip.documentView?.frame.height ?? 0) - clip.bounds.height
+            guard abs(clip.bounds.origin.y - top) > 0.5 else { return }
+            clip.scroll(to: NSPoint(x: clip.bounds.origin.x, y: top))
+            scrollView.reflectScrolledClipView(clip)
+        }
+    }
+
+    private static func firstScrollView(in view: NSView) -> NSScrollView? {
+        for subview in view.subviews {
+            if let scrollView = subview as? NSScrollView { return scrollView }
+            if let found = firstScrollView(in: subview) { return found }
+        }
+        return nil
     }
 
     /// The screen whose menu-bar band actually contains the status-item

--- a/native/LocalPackage/Sources/UserInterface/DashboardRootView.swift
+++ b/native/LocalPackage/Sources/UserInterface/DashboardRootView.swift
@@ -26,40 +26,34 @@ public struct DashboardRootView: View {
 
     public init() {}
 
-    // Anchor for resetting the scroll position on tab switches.
-    private static let scrollTopID = "dashboard-scroll-top"
-
     public var body: some View {
         ZStack {
             // The panel clamps to 1200pt; content taller than that scrolls.
-            ScrollViewReader { scrollProxy in
-                ScrollView(showsIndicators: false) {
-                    content
-                        .padding(16)
-                        .frame(maxWidth: .infinity, alignment: .top)
-                        .background(
-                            GeometryReader { proxy in
-                                Color.clear.preference(
-                                    key: ContentHeightKey.self,
-                                    value: max(
-                                        proxy.size.height,
-                                        store.isSettingsPresented
-                                            ? Self.settingsMinHeight : 0)
-                                )
-                            }
-                        )
-                        .id(Self.scrollTopID)
-                }
-                // Tab switches (click, ⌘1-9, ⌘[/⌘]) swap in content of a
-                // different natural height. AppKit keeps the old scroll
-                // offset, which on a shorter tab leaves the header pushed
-                // out of view and an empty band at the bottom of the panel
-                // (the panel resizes to the new content height while the
-                // stale offset survives). Match the web app — a tab switch
-                // always lands at the top.
-                .onChange(of: store.activeTab) { _ in
-                    scrollProxy.scrollTo(Self.scrollTopID, anchor: .top)
-                }
+            ScrollView(showsIndicators: false) {
+                content
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .top)
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear.preference(
+                                key: ContentHeightKey.self,
+                                value: max(
+                                    proxy.size.height,
+                                    store.isSettingsPresented
+                                        ? Self.settingsMinHeight : 0)
+                            )
+                        }
+                    )
+                    // Tab switches (click, ⌘1-9, ⌘[/⌘]) and reopening the
+                    // panel swap in content of a different natural height.
+                    // The clip view keeps its old offset, which pushes the
+                    // header out of view and leaves an empty band at the
+                    // bottom. Match the web app — always land at the top.
+                    .overlay(
+                        ScrollTopAnchor(trigger: AnyHashable(store.activeTab))
+                            .frame(width: 0, height: 0),
+                        alignment: .top
+                    )
             }
 
             if store.isSettingsPresented {
@@ -141,7 +135,8 @@ public struct DashboardRootView: View {
                 agentUsage: store.visibleAgentUsage,
                 liveClientIds: liveClientIds,
                 title: "\(ClientRegistry.style(for: clientId).displayName) limits",
-                note: "Session / weekly / model limits")
+                note: "Session / weekly / model limits",
+                includeUnlistedAgents: false)
             UsageBarChart(
                 title: "Token Usage",
                 subtitle: "Local token history",

--- a/native/LocalPackage/Sources/UserInterface/Views/AgentLimitsCard.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/AgentLimitsCard.swift
@@ -15,6 +15,9 @@ struct AgentLimitsCard: View {
     var liveClientIds: Set<String> = []
     var title: String = "Agent limits"
     var note: String = "OAuth quota"
+    /// Client tabs show only their own agent; the overview also folds in
+    /// agents that report quota but have no local logs yet.
+    var includeUnlistedAgents: Bool = true
 
     /// Placeholder rows while OAuth quota is loading; real windows come from
     /// the providers (mirror of LIMIT_ROWS in AgentLimitsCard.tsx:21-31).
@@ -37,11 +40,13 @@ struct AgentLimitsCard: View {
     private var visibleClients: [String] {
         var seen = Set<String>()
         var result: [String] = []
+        let known = snapshots
         for id in clients
-        where Self.limitRows[id] != nil
+        where Self.limitRows[id] != nil || known[id] != nil
             || ["codex", "claude", "gemini", "grok"].contains(id) {
             if seen.insert(id).inserted { result.append(id) }
         }
+        guard includeUnlistedAgents else { return result }
         for agent in agentUsage?.agents ?? [] {
             if seen.insert(agent.clientId).inserted { result.append(agent.clientId) }
         }
@@ -64,9 +69,11 @@ struct AgentLimitsCard: View {
                     .foregroundStyle(.secondary)
                     .padding(.vertical, 6)
             } else {
+                // Tiles stretch to fill the row: two agents get two
+                // half-width columns, not two thirds plus a blank third.
                 let columns = Array(
                     repeating: GridItem(.flexible(), spacing: 8, alignment: .top),
-                    count: visible.count == 1 ? 1 : 3)
+                    count: min(max(visible.count, 1), 3))
                 LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
                     ForEach(visible, id: \.self) { id in
                         agentTile(id: id, snapshot: snapshots[id])

--- a/native/LocalPackage/Sources/UserInterface/Views/ScrollTopAnchor.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/ScrollTopAnchor.swift
@@ -1,0 +1,64 @@
+import AppKit
+import SwiftUI
+
+// Forces the tray panel's scroll view back to the top.
+//
+// The panel sizes itself to the dashboard's natural height, so a tab switch
+// (or reopening the panel on a different tab) swaps in content of a different
+// height and resizes the window underneath a clip view that keeps its old
+// bounds origin. The result is the reported bug: the header and tab strip are
+// scrolled out of sight and an equally tall empty band sits at the bottom —
+// on content that isn't even scrollable any more.
+//
+// ScrollViewReader.scrollTo cannot fix that on its own: it runs in the same
+// update pass that reports the new ContentHeightKey, and the AppKit window
+// resize that follows re-applies the stale origin. So reach the underlying
+// NSScrollView and clamp it directly, once now and once after the resize has
+// landed.
+struct ScrollTopAnchor: NSViewRepresentable {
+    /// Any value change re-runs the reset (the active tab, in practice).
+    var trigger: AnyHashable
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.lastTrigger = trigger
+        context.coordinator.scheduleReset(from: view)
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        guard context.coordinator.lastTrigger != trigger else { return }
+        context.coordinator.lastTrigger = trigger
+        context.coordinator.scheduleReset(from: view)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    @MainActor
+    final class Coordinator {
+        var lastTrigger: AnyHashable?
+
+        /// Two passes: the first lands after SwiftUI's current update, the
+        /// second after the panel has resized to the new content height.
+        func scheduleReset(from view: NSView) {
+            DispatchQueue.main.async { [weak view] in
+                Self.scrollToTop(from: view)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak view] in
+                    Self.scrollToTop(from: view)
+                }
+            }
+        }
+
+        private static func scrollToTop(from view: NSView?) {
+            guard let scrollView = view?.enclosingScrollView else { return }
+            let clip = scrollView.contentView
+            // SwiftUI's document view is flipped, so the top is y == 0.
+            let top = clip.documentView?.isFlipped == false
+                ? (clip.documentView?.frame.height ?? 0) - clip.bounds.height
+                : 0
+            guard abs(clip.bounds.origin.y - top) > 0.5 else { return }
+            clip.scroll(to: NSPoint(x: clip.bounds.origin.x, y: top))
+            scrollView.reflectScrolledClipView(clip)
+        }
+    }
+}


### PR DESCRIPTION
## What

Clicking Claude/Codex (or coming back to Overview) left the dashboard header and tab strip clipped off the top of the tray panel, with an equally tall empty band at the bottom.

## Cause

`TrayPanelController.setContentHeight` called `panel.setFrame` straight from the `ContentHeightKey` preference — inside the same SwiftUI layout pass that reported the height. The hosting view finished laying out against the old window height, so the scroll view was sized to `new + (new - old)`. Logged over a tab round trip:

```
setContentHeight 791 (panel 885) -> doc 791, panel 791, scroll 698   # 93pt short
setContentHeight 885 (panel 791) -> doc 885, panel 885, scroll 977   # 93pt over
```

Deferring the resize to the next runloop turn fixes it; after the change `clip == doc == scrollView == panel` on every switch. `layoutSubtreeIfNeeded()` in the same pass does not help.

## Also in here

- Scroll position resets to the top on tab switches and on reopening the panel. Not the cause of this bug (the offset was always 0), but content past the 1200pt clamp really does scroll.
- The limits card unioned its `clients` argument with every agent in the quota payload, so the Claude tab's card also rendered a Codex CLI tile. That union is only wanted on the overview. The grid also hardcoded 3 columns, leaving the right third empty with two tiles.

## Test

`swift build` + 140 tests pass. Verified in the running app: opened the panel and drove Overview → Claude → Overview → Claude, checking the view geometry in logs and the rendering in screenshots.