### PR TITLE
Release Tokcat 0.2.5

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.4
-        CURRENT_PROJECT_VERSION: 5
+        MARKETING_VERSION: 0.2.5
+        CURRENT_PROJECT_VERSION: 6
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump only — `MARKETING_VERSION` 0.2.4 → 0.2.5, `CURRENT_PROJECT_VERSION` 5 → 6 (the published appcast's `sparkle:version` is 5, so Sparkle clients need 6 to see this).

Ships the fix already on main from #57:
- Switching to a client tab (or back to Overview) no longer clips the header off the top of the panel and leaves an empty band at the bottom — the panel now resizes outside the SwiftUI layout pass that reports the height.
- A client tab's limits card shows only that client's tile, filling the row instead of leaving the right third of the card empty.