### PR TITLE
feat(quota): keep the last good reading when a provider starts failing

### DIFF
--- a/native/LocalPackage/Sources/DataSource/Entities/AgentUsage.swift
+++ b/native/LocalPackage/Sources/DataSource/Entities/AgentUsage.swift
@@ -47,10 +47,16 @@ public struct AgentUsageSnapshot: Sendable, Codable, Equatable {
     public var windows: [UsageWindow]
     public var credits: CreditsSnapshot?
     public var error: String?
+    /// True when `windows` were carried over from an earlier successful
+    /// fetch because the current one failed (QuotaStore.carryingLastGood).
+    /// `updatedAt` then dates the numbers, not the failed attempt, and
+    /// `error` says why they stopped moving.
+    public var stale: Bool?
 
     public init(clientId: String, source: String, updatedAt: String,
                 identity: AgentIdentity? = nil, windows: [UsageWindow] = [],
-                credits: CreditsSnapshot? = nil, error: String? = nil) {
+                credits: CreditsSnapshot? = nil, error: String? = nil,
+                stale: Bool? = nil) {
         self.clientId = clientId
         self.source = source
         self.updatedAt = updatedAt
@@ -58,6 +64,7 @@ public struct AgentUsageSnapshot: Sendable, Codable, Equatable {
         self.windows = windows
         self.credits = credits
         self.error = error
+        self.stale = stale
     }
 }
 

--- a/native/LocalPackage/Sources/Model/Stores/QuotaStore.swift
+++ b/native/LocalPackage/Sources/Model/Stores/QuotaStore.swift
@@ -20,6 +20,11 @@ public final class QuotaStore: ObservableObject {
     public static let staleAfterSeconds: TimeInterval = 5 * 60
     /// REFRESH_SECS — the backend refresh cadence.
     private static let autoRefreshInterval: TimeInterval = 30 * 60
+    /// How long a failing provider may keep showing its last good reading
+    /// before the tile drops back to the bare error. A day out, every window
+    /// a provider reports (five-hourly, weekly, monthly) has either rolled
+    /// over or moved enough that the old numbers would mislead.
+    nonisolated public static let staleCarrySeconds: TimeInterval = 24 * 60 * 60
 
     // MARK: - Published state
 
@@ -144,11 +149,41 @@ public final class QuotaStore: ObservableObject {
         // (mirrors the generatedAtRef guard in useAgentUsage.ts).
         let stamp = Self.parseGeneratedAt(payload.generatedAt)
         if let stamp, let fetchedAt, stamp < fetchedAt { return }
-        self.payload = payload
-        self.fetchedAt = stamp ?? Date()
+        let now = stamp ?? Date()
+        self.payload = Self.carryingLastGood(payload, over: self.payload, now: now)
+        self.fetchedAt = now
     }
 
-    static func parseGeneratedAt(_ value: String) -> Date? {
+    /// A provider that fails reports an empty snapshot, which used to blank
+    /// the tile: an expired Claude token (#55) took the numbers with it, and
+    /// they only came back once the user ran `claude`. Keep the last good
+    /// reading instead, flagged `stale` and carrying the new error.
+    ///
+    /// The carried snapshot keeps its own `updatedAt`, so it dates the
+    /// numbers rather than the failed attempt — which is what bounds the
+    /// carry, and what lets the tile say how old they are.
+    nonisolated static func carryingLastGood(
+        _ payload: AgentUsagePayload, over previous: AgentUsagePayload?, now: Date
+    ) -> AgentUsagePayload {
+        guard let previous else { return payload }
+        var merged = payload
+        for index in merged.agents.indices {
+            let failed = merged.agents[index]
+            guard failed.error != nil, failed.windows.isEmpty,
+                  let last = previous.agents.first(where: { $0.clientId == failed.clientId }),
+                  !last.windows.isEmpty,
+                  let readAt = parseGeneratedAt(last.updatedAt),
+                  now.timeIntervalSince(readAt) < Self.staleCarrySeconds
+            else { continue }
+            var carried = last
+            carried.error = failed.error
+            carried.stale = true
+            merged.agents[index] = carried
+        }
+        return merged
+    }
+
+    nonisolated static func parseGeneratedAt(_ value: String) -> Date? {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f.date(from: value)

--- a/native/LocalPackage/Sources/UserInterface/Views/AgentLimitsCard.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/AgentLimitsCard.swift
@@ -108,6 +108,7 @@ struct AgentLimitsCard: View {
                 Text(statusText(snapshot: snapshot, isLive: isLive))
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(statusColor(snapshot: snapshot, isLive: isLive))
+                    .help(snapshot.map(Self.staleHelp) ?? "")
             }
             .padding(.bottom, 8)
 
@@ -126,6 +127,8 @@ struct AgentLimitsCard: View {
                     .help(snapshot.error ?? "")
             }
 
+            // Carried-over numbers are dimmed: still readable, visibly not
+            // the current reading (QuotaStore.carryingLastGood).
             VStack(alignment: .leading, spacing: 7) {
                 if let windows = snapshot?.windows, !windows.isEmpty {
                     ForEach(windows, id: \.label) { window in
@@ -143,6 +146,7 @@ struct AgentLimitsCard: View {
                     }
                 }
             }
+            .opacity(snapshot?.stale == true ? 0.5 : 1)
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -203,7 +207,32 @@ struct AgentLimitsCard: View {
 
     // MARK: - Status
 
+    private static let readAtParser: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let ageFormatter = RelativeDateTimeFormatter()
+
+    /// Tooltip for the status chip. A stale tile has to answer "how old?"
+    /// somewhere, and the chip is the part that claims the numbers are not
+    /// current; the error itself stays on the detail line.
+    static func staleHelp(_ snapshot: AgentUsageSnapshot) -> String {
+        let error = snapshot.error ?? ""
+        guard snapshot.stale == true,
+              let readAt = readAtParser.date(from: snapshot.updatedAt)
+        else { return error }
+        let ago = ageFormatter.localizedString(for: readAt, relativeTo: Date())
+        let note = "Last reading \(ago) — the numbers above are from then."
+        return error.isEmpty ? note : "\(error)\n\(note)"
+    }
+
     private func statusText(snapshot: AgentUsageSnapshot?, isLive: Bool) -> String {
+        // Stale outranks Error: the tile is still showing numbers, and
+        // saying only "Error" next to them would read as their being wrong
+        // rather than old.
+        if snapshot?.stale == true { return "Stale" }
         if snapshot?.error != nil { return "Error" }
         if let windows = snapshot?.windows, !windows.isEmpty {
             return snapshot?.source.uppercased() ?? ""
@@ -213,6 +242,7 @@ struct AgentLimitsCard: View {
     }
 
     private func statusColor(snapshot: AgentUsageSnapshot?, isLive: Bool) -> Color {
+        if snapshot?.stale == true { return .orange }
         if snapshot?.error != nil { return .red }
         if snapshot?.windows.isEmpty == false { return .secondary }
         if isLive { return .accentColor }

--- a/native/LocalPackage/Tests/ModelTests/QuotaStoreStaleCarryTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/QuotaStoreStaleCarryTests.swift
@@ -1,0 +1,191 @@
+import DataSource
+import Foundation
+import Testing
+
+@testable import Model
+
+// Carry-over of the last good quota reading when a provider starts failing.
+//
+// The tile used to blank when a provider errored: an expired Claude token
+// (#55) took the numbers with it until the user ran `claude`. The store now
+// keeps the previous reading, flagged stale and dated by its own updatedAt.
+
+private func stamp(_ text: String) -> Date {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f.date(from: text)!
+}
+
+private func good(
+    _ clientId: String, at updatedAt: String, remaining: Double = 40
+) -> AgentUsageSnapshot {
+    AgentUsageSnapshot(
+        clientId: clientId, source: "oauth", updatedAt: updatedAt,
+        identity: AgentIdentity(email: "a@b.c", plan: "max"),
+        windows: [UsageWindow(
+            label: "Session", usedPercent: 100 - remaining,
+            remainingPercent: remaining)])
+}
+
+private func failed(
+    _ clientId: String, at updatedAt: String, error: String = "token expired"
+) -> AgentUsageSnapshot {
+    AgentUsageSnapshot(
+        clientId: clientId, source: "oauth", updatedAt: updatedAt,
+        windows: [], error: error)
+}
+
+private func payload(_ generatedAt: String, _ agents: [AgentUsageSnapshot])
+    -> AgentUsagePayload
+{
+    AgentUsagePayload(generatedAt: generatedAt, agents: agents)
+}
+
+@Suite struct QuotaStoreStaleCarryTests {
+    @Test func keepsTheLastReadingWhenAProviderStartsFailing() {
+        let previous = payload(
+            "2026-01-01T00:00:00.000Z", [good("claude", at: "2026-01-01T00:00:00.000Z")])
+        let now = stamp("2026-01-01T00:30:00.000Z")
+        let merged = QuotaStore.carryingLastGood(
+            payload("2026-01-01T00:30:00.000Z", [failed("claude", at: "2026-01-01T00:30:00.000Z")]),
+            over: previous, now: now)
+
+        let claude = merged.agents[0]
+        #expect(claude.windows.first?.remainingPercent == 40)
+        #expect(claude.stale == true)
+        #expect(claude.error == "token expired")
+        // Dates the numbers, not the failed attempt — this is what bounds
+        // the carry and what the tile's "last reading" reads.
+        #expect(claude.updatedAt == "2026-01-01T00:00:00.000Z")
+        #expect(claude.identity?.email == "a@b.c")
+    }
+
+    @Test func aSuccessfulFetchReplacesTheCarriedReading() {
+        let previous = payload(
+            "2026-01-01T00:00:00.000Z",
+            [{ var s = good("claude", at: "2026-01-01T00:00:00.000Z"); s.stale = true; s.error = "token expired"; return s }()])
+        let fresh = good("claude", at: "2026-01-01T00:30:00.000Z", remaining: 12)
+        let merged = QuotaStore.carryingLastGood(
+            payload("2026-01-01T00:30:00.000Z", [fresh]),
+            over: previous, now: stamp("2026-01-01T00:30:00.000Z"))
+
+        #expect(merged.agents[0].windows.first?.remainingPercent == 12)
+        #expect(merged.agents[0].stale == nil)
+        #expect(merged.agents[0].error == nil)
+    }
+
+    /// Past the cap the old numbers describe windows that have rolled over,
+    /// so the tile drops back to the bare error.
+    @Test func stopsCarryingOnceTheReadingIsTooOld() {
+        let previous = payload(
+            "2026-01-01T00:00:00.000Z", [good("claude", at: "2026-01-01T00:00:00.000Z")])
+        let justInside = QuotaStore.carryingLastGood(
+            payload("2026-01-01T23:59:00.000Z", [failed("claude", at: "2026-01-01T23:59:00.000Z")]),
+            over: previous, now: stamp("2026-01-01T23:59:00.000Z"))
+        #expect(justInside.agents[0].stale == true)
+
+        let pastCap = QuotaStore.carryingLastGood(
+            payload("2026-01-02T00:01:00.000Z", [failed("claude", at: "2026-01-02T00:01:00.000Z")]),
+            over: previous, now: stamp("2026-01-02T00:01:00.000Z"))
+        #expect(pastCap.agents[0].windows.isEmpty)
+        #expect(pastCap.agents[0].stale == nil)
+        #expect(pastCap.agents[0].error == "token expired")
+    }
+
+    /// Repeated failures chain, but each carry keeps the original reading's
+    /// date, so the cap still terminates the chain.
+    @Test func chainedCarriesDoNotRefreshTheClock() {
+        var carried = payload(
+            "2026-01-01T00:00:00.000Z", [good("claude", at: "2026-01-01T00:00:00.000Z")])
+        for hour in 1...23 {
+            let at = String(format: "2026-01-01T%02d:00:00.000Z", hour)
+            carried = QuotaStore.carryingLastGood(
+                payload(at, [failed("claude", at: at)]), over: carried, now: stamp(at))
+        }
+        #expect(carried.agents[0].stale == true)
+        #expect(carried.agents[0].updatedAt == "2026-01-01T00:00:00.000Z")
+
+        let at = "2026-01-02T00:30:00.000Z"
+        let expired = QuotaStore.carryingLastGood(
+            payload(at, [failed("claude", at: at)]), over: carried, now: stamp(at))
+        #expect(expired.agents[0].windows.isEmpty)
+    }
+
+    /// A client that stops reporting entirely (logged out, so the provider
+    /// is no longer configured) must not be resurrected from the old payload.
+    @Test func doesNotResurrectAClientThatStoppedReporting() {
+        let previous = payload(
+            "2026-01-01T00:00:00.000Z",
+            [good("claude", at: "2026-01-01T00:00:00.000Z"),
+             good("codex", at: "2026-01-01T00:00:00.000Z")])
+        let merged = QuotaStore.carryingLastGood(
+            payload("2026-01-01T00:30:00.000Z", [good("codex", at: "2026-01-01T00:30:00.000Z")]),
+            over: previous, now: stamp("2026-01-01T00:30:00.000Z"))
+
+        #expect(merged.agents.count == 1)
+        #expect(merged.agents[0].clientId == "codex")
+    }
+
+    /// An error that still carries windows (a partial provider result) is
+    /// its own reading and is left alone.
+    @Test func leavesAnErrorThatStillReportsWindowsAlone() {
+        let previous = payload(
+            "2026-01-01T00:00:00.000Z", [good("claude", at: "2026-01-01T00:00:00.000Z")])
+        var partial = good("claude", at: "2026-01-01T00:30:00.000Z", remaining: 7)
+        partial.error = "weekly window unavailable"
+        let merged = QuotaStore.carryingLastGood(
+            payload("2026-01-01T00:30:00.000Z", [partial]),
+            over: previous, now: stamp("2026-01-01T00:30:00.000Z"))
+
+        #expect(merged.agents[0].windows.first?.remainingPercent == 7)
+        #expect(merged.agents[0].stale == nil)
+    }
+
+    @Test func firstPayloadHasNothingToCarry() {
+        let merged = QuotaStore.carryingLastGood(
+            payload("2026-01-01T00:00:00.000Z", [failed("claude", at: "2026-01-01T00:00:00.000Z")]),
+            over: nil, now: stamp("2026-01-01T00:00:00.000Z"))
+        #expect(merged.agents[0].windows.isEmpty)
+        #expect(merged.agents[0].stale == nil)
+    }
+}
+
+/// Counts provider calls off the main actor, so the injected closure stays
+/// `@Sendable` without capturing a mutable local.
+private actor CallCounter {
+    private var count = 0
+    func next() -> Int {
+        count += 1
+        return count
+    }
+}
+
+@Suite @MainActor struct QuotaStoreStaleCarryIntegrationTests {
+    /// End to end through refresh(): the published payload — the one the
+    /// Agent limits card and the tray title read — keeps the numbers.
+    @Test func publishedPayloadKeepsTheNumbersAcrossAFailure() async {
+        let store = QuotaStore()
+        let calls = CallCounter()
+        store.runProviders = {
+            await calls.next() == 1
+                ? payload(
+                    "2026-01-01T00:00:00.000Z", [good("claude", at: "2026-01-01T00:00:00.000Z")])
+                : payload(
+                    "2026-01-01T00:30:00.000Z", [failed("claude", at: "2026-01-01T00:30:00.000Z")])
+        }
+
+        store.refresh()
+        for _ in 0..<10_000 where store.isRefreshing { await Task.yield() }
+        #expect(store.payload?.agents.first?.stale == nil)
+
+        store.refresh()
+        for _ in 0..<10_000 where store.isRefreshing { await Task.yield() }
+        let claude = store.payload?.agents.first
+        #expect(claude?.stale == true)
+        #expect(claude?.windows.first?.remainingPercent == 40)
+        #expect(claude?.error == "token expired")
+        // Still counted as a plan source, so the settings radios and the
+        // tray percentage do not drop out mid-error.
+        #expect(store.planSnapshots["claude"] != nil)
+    }
+}


### PR DESCRIPTION
Follow-up to #56 (the item I flagged in review there).

## Problem

A provider that fails returns a snapshot with `windows: []` and an `error`, so the tile blanked. The expired-token error from #55 replaced exactly the numbers the user opened the panel to read, and they only came back once the user ran `claude`. Worse, `planSnapshots` filters on `!windows.isEmpty`, so the plan radios in Settings and the tray percentage dropped out too.

## Approach

`QuotaStore.carryingLastGood` merges each new payload over the previous one: a snapshot that failed *and* reports no windows inherits the last good reading, flagged `stale`, with the new error attached.

The carried snapshot keeps its **own** `updatedAt` rather than the failed attempt's. That is what makes the age truthful, what bounds the carry, and what the tile reads to say how old the numbers are. Repeated failures therefore chain without refreshing the clock.

The carry is capped at 24h (`staleCarrySeconds`): past a day, every window a provider reports — five-hourly, weekly, monthly — has rolled over, so the tile drops back to the bare error.

Deliberately narrow:
- Only when the new snapshot has **no** windows. A partial result that still reports windows is its own reading and is left alone.
- Only for clients present in the new payload. A client that stops reporting entirely (logged out → provider no longer configured) is not resurrected from the old payload.

## UI

- Status chip reads **Stale** in orange, not red **Error**. The numbers are still on screen; "Error" next to them reads as their being *wrong* rather than *old*.
- Bars dim to 50% — readable, visibly not the current reading.
- The chip's tooltip carries the error plus "Last reading N hours ago — the numbers above are from then." The error text itself stays on the detail line where it already was.

`AgentUsageSnapshot` gains an optional `stale` flag so the state rides along with the data. The payload is not persisted or exchanged with anything, and the field is optional, so decoding is unaffected.

## Testing

`swift test` in `native/LocalPackage`: **157 tests / 29 suites** pass (149 before).

`QuotaStoreStaleCarryTests` (new) covers the carry, recovery on the next success, the cap from both sides (23h59m carries, 24h01m does not), chained carries not refreshing the clock, the two exclusions above, and the first-payload case. One integration test drives it through `refresh()` and asserts on the published payload — including that `planSnapshots` still lists the client mid-error.

App target built for real this time: `xcodegen generate && xcodebuild -scheme Tokcat` → BUILD SUCCEEDED.

> Note: I have not exercised the stale tile visually — it needs a provider to start failing after a good fetch. The rendering path is the existing one with an opacity and two string changes, and the logic driving it is covered by tests.