### PR TITLE
Release Tokcat 0.2.6

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.5
-        CURRENT_PROJECT_VERSION: 6
+        MARKETING_VERSION: 0.2.6
+        CURRENT_PROJECT_VERSION: 7
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump only — `MARKETING_VERSION` 0.2.5 → 0.2.6, `CURRENT_PROJECT_VERSION` 6 → 7 (must exceed the last release's `sparkle:version`).

Shipping since 0.2.5:
- #56 — Tokcat no longer redeems the Claude refresh token. Reading usage could rotate the token server-side while the Keychain kept the spent one, which could silently log Claude Code out. Refresh is now `claude`'s job; an expired token is reported instead. Refresh (button / menu / ⌘R) also drives the quota store, so the fix is picked up on the press rather than on the next 30-minute tick.
- #59 — A failing provider keeps its last good reading (dimmed, badged "Stale", age in the tooltip) instead of blanking the tile, and stays a plan source so the Settings radios and tray percentage do not drop out mid-error.

Tag `v0.2.6` goes up once this merges; `release-native.yml` builds and publishes all five assets from it.