### PR TITLE
perf(tail): scan session roots with getattrlistbulk

### DIFF
--- a/native/LocalPackage/Sources/Collector/Support/DirScan.swift
+++ b/native/LocalPackage/Sources/Collector/Support/DirScan.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+// Bulk directory enumeration for the live tailer's hot loop.
+//
+// UsageTailer.tick() re-walks every Claude/Codex/Grok session root once per
+// TAIL_TICK_SECS to spot file growth, which on a working machine means a few
+// thousand entries every 5 seconds. Doing that with
+// FileManager.contentsOfDirectory + one lstat per entry cost ~2.3% CPU
+// continuously (measured with `sample`: ~35% of it inside CoreServices'
+// URL enumerator, ~25% in lstat) — an order of magnitude more energy than a
+// menu-bar app should draw.
+//
+// getattrlistbulk returns name + object type + mtime + data length for many
+// entries per syscall, so one directory costs a couple of syscalls instead of
+// 1 + N. Semantics match the previous readdir/lstat pair: entries are
+// described as themselves, symlinks are NOT followed.
+//
+// Set TOKCAT_NO_BULK_SCAN=1 to force the readdir + lstat fallback (also used
+// automatically on any filesystem that rejects getattrlistbulk).
+
+/// One directory entry with the attributes the tailer needs.
+struct DirEntryInfo: Equatable {
+    var name: String
+    var isDir: Bool
+    var isRegular: Bool
+    /// Data-fork length; 0 for non-regular entries.
+    var size: UInt64
+    /// mtime in whole milliseconds; 0 for pre-epoch/unavailable, matching
+    /// `statMtimeMs`.
+    var mtimeMs: Int64
+}
+
+// vnode types from sys/vnode.h (not re-exported by the Darwin module).
+private let vtypeRegular: UInt32 = 1  // VREG
+private let vtypeDirectory: UInt32 = 2  // VDIR
+
+// The ATTR_* macros import with mixed signedness (ATTR_CMN_RETURNED_ATTRS is
+// 0x80000000); normalize them to attrgroup_t once.
+private let attrCmnReturnedAttrs = attrgroup_t(truncatingIfNeeded: ATTR_CMN_RETURNED_ATTRS)
+private let attrCmnName = attrgroup_t(truncatingIfNeeded: ATTR_CMN_NAME)
+private let attrCmnObjType = attrgroup_t(truncatingIfNeeded: ATTR_CMN_OBJTYPE)
+private let attrCmnModTime = attrgroup_t(truncatingIfNeeded: ATTR_CMN_MODTIME)
+private let attrFileDataLength = attrgroup_t(truncatingIfNeeded: ATTR_FILE_DATALENGTH)
+
+private let bulkScanDisabled: Bool =
+    ProcessInfo.processInfo.environment["TOKCAT_NO_BULK_SCAN"] == "1"
+
+/// Enumerate `path`, returning every entry (excluding `.`/`..`) with its
+/// type, size and mtime. Empty when the directory can't be read.
+func scanDirectory(_ path: String) -> [DirEntryInfo] {
+    scanDirectoryForTesting(path, forceFallback: bulkScanDisabled)
+}
+
+/// `scanDirectory` with the bulk path switchable, so tests can assert the two
+/// implementations agree.
+func scanDirectoryForTesting(_ path: String, forceFallback: Bool) -> [DirEntryInfo] {
+    if !forceFallback, let bulk = scanDirectoryBulk(path) { return bulk }
+    return scanDirectoryFallback(path)
+}
+
+// MARK: - getattrlistbulk
+
+private func scanDirectoryBulk(_ path: String) -> [DirEntryInfo]? {
+    let fd = open(path, O_RDONLY | O_DIRECTORY)
+    guard fd >= 0 else { return nil }
+    defer { close(fd) }
+
+    var request = attrlist()
+    request.bitmapcount = u_short(ATTR_BIT_MAP_COUNT)
+    request.commonattr =
+        attrCmnReturnedAttrs | attrCmnName | attrCmnObjType | attrCmnModTime
+    request.fileattr = attrFileDataLength
+
+    var out: [DirEntryInfo] = []
+    var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+    while true {
+        let returned: Int = buffer.withUnsafeMutableBytes { raw in
+            guard let base = raw.baseAddress else { return -1 }
+            return Int(getattrlistbulk(fd, &request, base, raw.count, 0))
+        }
+        if returned == 0 { break }  // no more entries
+        if returned < 0 {
+            // Unsupported (or a mid-walk failure): let the caller's fallback
+            // produce the whole listing rather than a partial one.
+            return nil
+        }
+        let ok = buffer.withUnsafeBytes { raw -> Bool in
+            guard let base = raw.baseAddress else { return false }
+            return decodeBulkEntries(base, limit: raw.count, count: returned, into: &out)
+        }
+        guard ok else { return nil }
+    }
+    return out
+}
+
+/// Walk `count` packed attribute records. getattrlist packs fields back to
+/// back in canonical bitmap order with no alignment padding, so every read is
+/// unaligned; each record's leading `u_int32_t` length includes its trailing
+/// variable-length data.
+private func decodeBulkEntries(
+    _ base: UnsafeRawPointer, limit: Int, count: Int, into out: inout [DirEntryInfo]
+) -> Bool {
+    var entry = base
+    var consumed = 0
+    for _ in 0..<count {
+        guard limit - consumed >= MemoryLayout<UInt32>.size else { return false }
+        let length = Int(entry.loadUnaligned(as: UInt32.self))
+        guard length > 0, consumed + length <= limit else { return false }
+
+        var offset = MemoryLayout<UInt32>.size
+        let returnedAttrs = entry.loadUnaligned(
+            fromByteOffset: offset, as: attribute_set_t.self)
+        offset += MemoryLayout<attribute_set_t>.size
+
+        var name = ""
+        if returnedAttrs.commonattr & attrCmnName != 0 {
+            let reference = entry.loadUnaligned(
+                fromByteOffset: offset, as: attrreference_t.self)
+            let nameOffset = offset + Int(reference.attr_dataoffset)
+            guard nameOffset >= 0, nameOffset < length else { return false }
+            name = String(
+                cString: entry.advanced(by: nameOffset).assumingMemoryBound(to: CChar.self))
+            offset += MemoryLayout<attrreference_t>.size
+        }
+
+        var objectType: UInt32 = 0
+        if returnedAttrs.commonattr & attrCmnObjType != 0 {
+            objectType = entry.loadUnaligned(fromByteOffset: offset, as: UInt32.self)
+            offset += MemoryLayout<UInt32>.size
+        }
+
+        var mtimeMs: Int64 = 0
+        if returnedAttrs.commonattr & attrCmnModTime != 0 {
+            let modified = entry.loadUnaligned(fromByteOffset: offset, as: timespec.self)
+            mtimeMs = timespecToMs(modified)
+            offset += MemoryLayout<timespec>.size
+        }
+
+        var size: UInt64 = 0
+        if returnedAttrs.fileattr & attrFileDataLength != 0 {
+            let dataLength = entry.loadUnaligned(fromByteOffset: offset, as: off_t.self)
+            size = dataLength > 0 ? UInt64(dataLength) : 0
+        }
+
+        if name != "." && name != ".." && !name.isEmpty {
+            let isRegular = objectType == vtypeRegular
+            out.append(DirEntryInfo(
+                name: name,
+                isDir: objectType == vtypeDirectory,
+                isRegular: isRegular,
+                // The kernel reports a data length for symlinks too (the
+                // target string); only a regular file's length is a size.
+                size: isRegular ? size : 0,
+                mtimeMs: mtimeMs))
+        }
+
+        entry = entry.advanced(by: length)
+        consumed += length
+    }
+    return true
+}
+
+// MARK: - readdir + lstat fallback
+
+private func scanDirectoryFallback(_ path: String) -> [DirEntryInfo] {
+    guard let dir = opendir(path) else { return [] }
+    defer { closedir(dir) }
+    var out: [DirEntryInfo] = []
+    while let entry = readdir(dir) {
+        let name = withUnsafeBytes(of: &entry.pointee.d_name) { raw -> String in
+            String(cString: raw.baseAddress!.assumingMemoryBound(to: CChar.self))
+        }
+        if name == "." || name == ".." { continue }
+        // lstat, not d_type: the tailer needs size and mtime anyway.
+        var sb = stat()
+        guard lstat(joinPath(path, name), &sb) == 0 else { continue }
+        let mode = sb.st_mode & S_IFMT
+        out.append(DirEntryInfo(
+            name: name,
+            isDir: mode == S_IFDIR,
+            isRegular: mode == S_IFREG,
+            size: mode == S_IFREG ? UInt64(max(sb.st_size, 0)) : 0,
+            mtimeMs: timespecToMs(sb.st_mtimespec)))
+    }
+    return out
+}
+
+private func timespecToMs(_ ts: timespec) -> Int64 {
+    let seconds = Int64(ts.tv_sec)
+    guard seconds >= 0 else { return 0 }
+    return seconds * 1000 + Int64(ts.tv_nsec) / 1_000_000
+}

--- a/native/LocalPackage/Sources/Collector/Support/FileScan.swift
+++ b/native/LocalPackage/Sources/Collector/Support/FileScan.swift
@@ -73,6 +73,13 @@ func rustExtension(_ path: String) -> String? {
     return String(name[name.index(after: dot)...])
 }
 
+/// `rustExtension(name) == "jsonl"` for a bare file name, without splitting.
+/// A name that is exactly ".jsonl" is hidden and has no extension, matching
+/// `rustExtension`'s leading-dot rule.
+func hasJSONLExtension(_ name: String) -> Bool {
+    name.utf8.count > 6 && name.hasSuffix(".jsonl")
+}
+
 /// `Path::file_name()`: the final path component.
 func rustFileName(_ path: String) -> String? {
     let name = path.split(separator: "/", omittingEmptySubsequences: true).last

--- a/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
+++ b/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
@@ -147,29 +147,32 @@ public actor UsageTailer {
         for (root, client) in tailRoots() {
             var stack = [root]
             while let dir = stack.popLast() {
-                guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir)
-                else { continue }
-                for name in entries {
-                    let path = joinPath(dir, name)
-                    // Rust's DirEntry::file_type / DirEntry::metadata do not
-                    // traverse symlinks — mirror with lstat.
-                    var sb = stat()
-                    guard lstat(path, &sb) == 0 else { continue }
-                    let mode = sb.st_mode & S_IFMT
-                    if mode == S_IFDIR {
-                        stack.append(path)
+                // One getattrlistbulk pass per directory instead of a
+                // listing plus an lstat per entry: this loop runs every 5s
+                // over every session file on the machine, and the syscall
+                // count was the app's dominant energy cost. Symlinks are
+                // still described as themselves, matching Rust's
+                // DirEntry::file_type / DirEntry::metadata.
+                for entry in scanDirectory(dir) {
+                    if entry.isDir {
+                        stack.append(joinPath(dir, entry.name))
                         continue
                     }
-                    guard mode == S_IFREG else { continue }
-                    guard rustExtension(path) == "jsonl" else { continue }
+                    guard entry.isRegular else { continue }
+                    // Filter on the bare name before building the full path:
+                    // rustExtension/rustFileName each split the whole path
+                    // into an array of components, and almost every entry
+                    // here is discarded.
+                    guard hasJSONLExtension(entry.name) else { continue }
                     // Grok session dirs also contain events.jsonl /
                     // chat_history.jsonl; only updates.jsonl carries
                     // cumulative totalTokens for the live rate signal.
-                    if client == .grok, rustFileName(path) != "updates.jsonl" {
+                    if client == .grok, entry.name != "updates.jsonl" {
                         continue
                     }
-                    let size = UInt64(sb.st_size)
-                    let mtimeMs = statMtimeMs(sb)
+                    let path = joinPath(dir, entry.name)
+                    let size = entry.size
+                    let mtimeMs = entry.mtimeMs
                     let prev = files[path].map { ($0.offset, $0.mtimeMs) }
 
                     if isCold, prev == nil, mtimeMs < coldCutoffMs {
@@ -182,10 +185,15 @@ public actor UsageTailer {
                     let startOffset = prev?.0 ?? 0
                     if size == startOffset {
                         // Preserve codex/grok thread state when only mtime
-                        // refreshes without growth (:183-193).
-                        if files[path] != nil {
-                            files[path]!.offset = size
-                            files[path]!.mtimeMs = mtimeMs
+                        // refreshes without growth (:183-193). The offset
+                        // already equals `size` here, so an unchanged mtime
+                        // means there is nothing to write back — and skipping
+                        // the write matters: this is the branch every dormant
+                        // session file takes on every tick.
+                        if let existing = files[path] {
+                            if existing.mtimeMs != mtimeMs {
+                                files[path]!.mtimeMs = mtimeMs
+                            }
                         } else {
                             files[path] = .atEOF(size: size, mtimeMs: mtimeMs)
                         }
@@ -716,10 +724,3 @@ func sidechainLabelFromPath(_ path: String) -> String {
     return "subagent:\(stem)"
 }
 
-private func statMtimeMs(_ sb: stat) -> Int64 {
-    // system_time_to_ms returns 0 for pre-epoch/errored mtimes.
-    let sec = Int64(sb.st_mtimespec.tv_sec)
-    let nsec = Int64(sb.st_mtimespec.tv_nsec)
-    if sec < 0 { return 0 }
-    return sec * 1000 + nsec / 1_000_000
-}

--- a/native/LocalPackage/Tests/CollectorTests/DirScanTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/DirScanTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import Collector
+
+// The getattrlistbulk decoder hand-parses packed kernel records, so the
+// contract it must hold is "identical to readdir + lstat" — that is what the
+// tailer's growth detection was built on.
+struct DirScanTests {
+    private func tempDir(_ name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "tokcat-dirscan-\(name)-\(ProcessInfo.processInfo.processIdentifier)-\(nowMs())")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func bulkScanMatchesReaddirAndLstat() throws {
+        let dir = try tempDir("mixed")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try "hello".write(to: dir.appendingPathComponent("a.jsonl"), atomically: true,
+                          encoding: .utf8)
+        try "".write(to: dir.appendingPathComponent("empty.jsonl"), atomically: true,
+                     encoding: .utf8)
+        // A long name pushes the record past one 8-byte alignment boundary.
+        try String(repeating: "x", count: 4096).write(
+            to: dir.appendingPathComponent(String(repeating: "n", count: 120) + ".jsonl"),
+            atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("sub"), withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: dir.appendingPathComponent("link.jsonl"),
+            withDestinationURL: dir.appendingPathComponent("a.jsonl"))
+
+        let bulk = scanDirectory(dir.path).sorted { $0.name < $1.name }
+        let fallback = scanDirectoryForTesting(dir.path, forceFallback: true)
+            .sorted { $0.name < $1.name }
+
+        #expect(bulk == fallback)
+        #expect(bulk.count == 5)
+
+        let byName = Dictionary(uniqueKeysWithValues: bulk.map { ($0.name, $0) })
+        #expect(byName["a.jsonl"]?.isRegular == true)
+        #expect(byName["a.jsonl"]?.size == 5)
+        #expect(byName["empty.jsonl"]?.size == 0)
+        #expect(byName["sub"]?.isDir == true)
+        // A symlink must be described as itself, not its target: the tailer
+        // relies on not following links.
+        #expect(byName["link.jsonl"]?.isDir == false)
+        #expect(byName["link.jsonl"]?.isRegular == false)
+    }
+
+    @Test func mtimeSurvivesTheRoundTrip() throws {
+        let dir = try tempDir("mtime")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("s.jsonl")
+        try "x".write(to: file, atomically: true, encoding: .utf8)
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        try FileManager.default.setAttributes(
+            [.modificationDate: stamp], ofItemAtPath: file.path)
+
+        let entry = scanDirectory(dir.path).first { $0.name == "s.jsonl" }
+        #expect(entry?.mtimeMs == 1_700_000_000_000)
+    }
+
+    // Growth must be visible on the very next scan — this is the signal the
+    // 5s tick reads.
+    @Test func sizeReflectsAppendedBytes() throws {
+        let dir = try tempDir("growth")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent("g.jsonl").path
+        try "abc".write(toFile: path, atomically: true, encoding: .utf8)
+        #expect(scanDirectory(dir.path).first { $0.name == "g.jsonl" }?.size == 3)
+
+        let handle = FileHandle(forWritingAtPath: path)!
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("defg".utf8))
+        try handle.close()
+        #expect(scanDirectory(dir.path).first { $0.name == "g.jsonl" }?.size == 7)
+    }
+
+    @Test func unreadableDirectoryScansEmpty() throws {
+        #expect(scanDirectory("/nope/does/not/exist").isEmpty)
+    }
+
+    @Test func manyEntriesSpanMultipleBulkCalls() throws {
+        let dir = try tempDir("many")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // Comfortably more entries than one 64K buffer holds in a single
+        // getattrlistbulk call, so the resume path is exercised.
+        for i in 0..<1500 {
+            try "\(i)".write(to: dir.appendingPathComponent("f\(i).jsonl"),
+                             atomically: true, encoding: .utf8)
+        }
+        let bulk = scanDirectory(dir.path).sorted { $0.name < $1.name }
+        let fallback = scanDirectoryForTesting(dir.path, forceFallback: true)
+            .sorted { $0.name < $1.name }
+        #expect(bulk.count == 1500)
+        #expect(bulk == fallback)
+    }
+}
+
+struct JSONLExtensionTests {
+    // The tailer's hot loop uses hasJSONLExtension in place of
+    // rustExtension(path) == "jsonl"; they must agree on every name.
+    @Test(arguments: [
+        "a.jsonl", "session.jsonl", ".jsonl", "jsonl", "a.jsonl.gz", "a.json",
+        "x.JSONL", ".hidden.jsonl", "a.b.jsonl", "", ".", "..", "updates.jsonl",
+    ])
+    func matchesRustExtension(name: String) {
+        #expect(hasJSONLExtension(name) == (rustExtension(name) == "jsonl"))
+    }
+}

--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.6
-        CURRENT_PROJECT_VERSION: 7
+        MARKETING_VERSION: 0.2.7
+        CURRENT_PROJECT_VERSION: 8
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
## Why

Tokcat idled at ~2.4% CPU — roughly 4x RunCat on the same machine. `sample` traced essentially all of it to one place:

```
LiveTraceStore.start() → UsageTailer.tick()
  ├─ FileManager.contentsOfDirectory   (35%)   ← CoreServices URL enumerator
  ├─ lstat                             (25%)
  └─ per-entry path splitting          (rest)
```

The 5s live-rate tick re-walks every Claude/Codex/Grok session root — here 2,608 + 1,678 entries — twelve times a minute, with a Foundation URL enumerator per directory and an `lstat` per entry.

## What changed

- **`getattrlistbulk` scanner** (`Collector/Support/DirScan.swift`): name, type, mtime and size for many entries per syscall. A directory costs 2–3 syscalls instead of 1 + N.
- **Filter on the bare name before building the path**: `rustExtension`/`rustFileName` each split the whole path into an array, and nearly every entry is discarded.
- **Skip no-op dictionary write-backs**: the unchanged-size branch was rewriting `offset`/`mtime` to the same values every tick — the branch every dormant session file takes.

## Results

One `tick()` over the real home, release build:

| | tick | CPU |
|---|---|---|
| before | 73.3 ms | ~1.5% |
| after | **12.3 ms** | **~0.25%** |

Whole app measured against RunCat over the same 90s window: **Tokcat 0.79%, RunCat 0.69%** (was 2.4%).

## Safety

Semantics are unchanged — entries are described as themselves, symlinks are not followed. Filesystems that reject `getattrlistbulk` fall back to `readdir + lstat`; `TOKCAT_NO_BULK_SCAN=1` forces that path.

The decoder hand-parses packed kernel records, so the new tests assert it agrees byte-for-byte with `readdir + lstat`: symlinks, empty files, 120-char names, 1,500 entries spanning multiple bulk calls, mtime round-trip, and `hasJSONLExtension` ≡ `rustExtension(...) == "jsonl"`.

163 tests pass.

## Release

Includes the `Release Tokcat 0.2.7` bump (`MARKETING_VERSION` 0.2.7, `CURRENT_PROJECT_VERSION` 8).