### PR TITLE
perf(tail): prune the tick walk by directory mtime

### DIFF
--- a/native/LocalPackage/Sources/Collector/Support/DirScan.swift
+++ b/native/LocalPackage/Sources/Collector/Support/DirScan.swift
@@ -25,9 +25,13 @@ struct DirEntryInfo: Equatable {
     var isRegular: Bool
     /// Data-fork length; 0 for non-regular entries.
     var size: UInt64
-    /// mtime in whole milliseconds; 0 for pre-epoch/unavailable, matching
-    /// `statMtimeMs`.
-    var mtimeMs: Int64
+    /// mtime in nanoseconds; 0 for pre-epoch/unavailable. Full precision
+    /// matters for the tailer's directory pruning: two changes inside the
+    /// same millisecond would otherwise look like none.
+    var mtimeNs: Int64
+
+    /// mtime in whole milliseconds, matching `statMtimeMs`.
+    var mtimeMs: Int64 { mtimeNs / 1_000_000 }
 }
 
 // vnode types from sys/vnode.h (not re-exported by the Darwin module).
@@ -129,10 +133,10 @@ private func decodeBulkEntries(
             offset += MemoryLayout<UInt32>.size
         }
 
-        var mtimeMs: Int64 = 0
+        var mtimeNs: Int64 = 0
         if returnedAttrs.commonattr & attrCmnModTime != 0 {
             let modified = entry.loadUnaligned(fromByteOffset: offset, as: timespec.self)
-            mtimeMs = timespecToMs(modified)
+            mtimeNs = timespecToNs(modified)
             offset += MemoryLayout<timespec>.size
         }
 
@@ -151,7 +155,7 @@ private func decodeBulkEntries(
                 // The kernel reports a data length for symlinks too (the
                 // target string); only a regular file's length is a size.
                 size: isRegular ? size : 0,
-                mtimeMs: mtimeMs))
+                mtimeNs: mtimeNs))
         }
 
         entry = entry.advanced(by: length)
@@ -180,13 +184,13 @@ private func scanDirectoryFallback(_ path: String) -> [DirEntryInfo] {
             isDir: mode == S_IFDIR,
             isRegular: mode == S_IFREG,
             size: mode == S_IFREG ? UInt64(max(sb.st_size, 0)) : 0,
-            mtimeMs: timespecToMs(sb.st_mtimespec)))
+            mtimeNs: timespecToNs(sb.st_mtimespec)))
     }
     return out
 }
 
-private func timespecToMs(_ ts: timespec) -> Int64 {
+private func timespecToNs(_ ts: timespec) -> Int64 {
     let seconds = Int64(ts.tv_sec)
     guard seconds >= 0 else { return 0 }
-    return seconds * 1000 + Int64(ts.tv_nsec) / 1_000_000
+    return seconds * 1_000_000_000 + Int64(ts.tv_nsec)
 }

--- a/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
+++ b/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
@@ -18,6 +18,11 @@ let tailClientHermes = "hermes"
 let tailClientGrok = "grok"
 let eventWindowSecs: Int64 = 3600  // EVENT_WINDOW_SECS (:26)
 let coldScanLookbackSecs: Int64 = 6 * 3600  // COLD_SCAN_LOOKBACK_SECS (:27)
+/// A file touched this recently is re-stat'd on every tick even when its
+/// directory is pruned from the walk (see `tick`).
+let activeFileWindowSecs: Int64 = 600
+/// How often the walk ignores directory-mtime pruning and visits everything.
+public let defaultFullScanIntervalMs: Int64 = 60_000
 
 enum TailClientKind: Equatable, Sendable {
     case claude
@@ -109,10 +114,15 @@ struct HermesTailSnapshot: Equatable {
 public struct UsageTailerConfig: Sendable {
     public var simulatedHome: String?
     public var nowMs: (@Sendable () -> Int64)?
+    /// Interval between unpruned walks. `0` makes every tick a full walk,
+    /// which is what the pre-pruning tailer did.
+    public var fullScanIntervalMs: Int64
 
-    public init(simulatedHome: String? = nil, nowMs: (@Sendable () -> Int64)? = nil) {
+    public init(simulatedHome: String? = nil, nowMs: (@Sendable () -> Int64)? = nil,
+                fullScanIntervalMs: Int64 = defaultFullScanIntervalMs) {
         self.simulatedHome = simulatedHome
         self.nowMs = nowMs
+        self.fullScanIntervalMs = fullScanIntervalMs
     }
 }
 
@@ -122,6 +132,13 @@ public actor UsageTailer {
     private(set) var seen: [String: Int] = [:]
     private var cold = true
     private var hermesSnapshots: [String: HermesTailSnapshot] = [:]
+    /// Last mtime seen for each directory, keyed by path — the walk's pruning
+    /// signal. Nanoseconds, so two changes inside one millisecond can't cancel
+    /// out into "unchanged".
+    private var dirMtimes: [String: Int64] = [:]
+    /// Files recently written to, re-stat'd every tick regardless of pruning.
+    var activeFiles: [String: TailClientKind] = [:]  // internal for tests
+    private var lastFullScanMs: Int64 = 0
     private let config: UsageTailerConfig
 
     public init(config: UsageTailerConfig = UsageTailerConfig()) {
@@ -135,27 +152,54 @@ public actor UsageTailer {
     // MARK: - Tick (usage_tail.rs:123-210)
 
     /// Scan all roots for growth, appending events. Returns events added.
+    ///
+    /// Two tiers, because walking every session root on the machine every 5
+    /// seconds was the app's dominant energy cost:
+    ///
+    ///   - Every tick prunes the walk by directory mtime. A directory's mtime
+    ///     moves when an entry is created, removed or renamed inside it, and
+    ///     never when a file it already holds simply grows — so an unchanged
+    ///     mtime proves there are no NEW session files below, and the walk can
+    ///     skip that subtree. New files are still picked up within one tick.
+    ///   - Growth of files we already know about is covered by re-stat'ing the
+    ///     active set (anything touched in the last `activeFileWindowSecs`),
+    ///     which is a handful of files rather than thousands.
+    ///
+    /// The one case neither tier catches is a dormant file that starts growing
+    /// again — a resumed session idle for more than the active window. The
+    /// unpruned walk every `fullScanIntervalMs` is the backstop for it: the
+    /// growth is delayed, never lost, since `readGrowth` resumes from the
+    /// stored offset.
     @discardableResult
     public func tick() -> Int {
         var added = 0
         let isCold = cold
         cold = false
-        let coldCutoffMs = now() - coldScanLookbackSecs * 1000
+        let nowMs = now()
+        let coldCutoffMs = nowMs - coldScanLookbackSecs * 1000
 
         added += tickHermes(isCold: isCold)
+
+        let isFullScan = isCold || nowMs - lastFullScanMs >= config.fullScanIntervalMs
+        if isFullScan { lastFullScanMs = nowMs }
+        // Only needed to keep the active pass from re-reading a file the walk
+        // already handled, and the walk touches few files when it is pruned.
+        var walked: Set<String> = []
 
         for (root, client) in tailRoots() {
             var stack = [root]
             while let dir = stack.popLast() {
                 // One getattrlistbulk pass per directory instead of a
-                // listing plus an lstat per entry: this loop runs every 5s
-                // over every session file on the machine, and the syscall
-                // count was the app's dominant energy cost. Symlinks are
-                // still described as themselves, matching Rust's
+                // listing plus an lstat per entry. Symlinks are still
+                // described as themselves, matching Rust's
                 // DirEntry::file_type / DirEntry::metadata.
                 for entry in scanDirectory(dir) {
                     if entry.isDir {
-                        stack.append(joinPath(dir, entry.name))
+                        let subdir = joinPath(dir, entry.name)
+                        if isFullScan || dirMtimes[subdir] != entry.mtimeNs {
+                            stack.append(subdir)
+                        }
+                        dirMtimes[subdir] = entry.mtimeNs
                         continue
                     }
                     guard entry.isRegular else { continue }
@@ -171,51 +215,84 @@ public actor UsageTailer {
                         continue
                     }
                     let path = joinPath(dir, entry.name)
-                    let size = entry.size
-                    let mtimeMs = entry.mtimeMs
-                    let prev = files[path].map { ($0.offset, $0.mtimeMs) }
-
-                    if isCold, prev == nil, mtimeMs < coldCutoffMs {
-                        // Cold scan: stamp old files at EOF without reading
-                        // (usage_tail.rs:175-179).
-                        files[path] = .atEOF(size: size, mtimeMs: mtimeMs)
-                        continue
-                    }
-
-                    let startOffset = prev?.0 ?? 0
-                    if size == startOffset {
-                        // Preserve codex/grok thread state when only mtime
-                        // refreshes without growth (:183-193). The offset
-                        // already equals `size` here, so an unchanged mtime
-                        // means there is nothing to write back — and skipping
-                        // the write matters: this is the branch every dormant
-                        // session file takes on every tick.
-                        if let existing = files[path] {
-                            if existing.mtimeMs != mtimeMs {
-                                files[path]!.mtimeMs = mtimeMs
-                            }
-                        } else {
-                            files[path] = .atEOF(size: size, mtimeMs: mtimeMs)
-                        }
-                        continue
-                    }
-                    if size < startOffset {
-                        // Truncated / rotated log — drop threaded counters so
-                        // we re-baseline instead of treating a new smaller
-                        // total as a negative delta (:196-200).
-                        files[path] = nil
-                        added += readGrowth(path: path, client: client,
-                                            start: 0, end: size, mtimeMs: mtimeMs)
-                    } else {
-                        added += readGrowth(path: path, client: client,
-                                            start: startOffset, end: size, mtimeMs: mtimeMs)
-                    }
+                    if !isFullScan { walked.insert(path) }
+                    added += processFile(
+                        path: path, client: client, size: entry.size,
+                        mtimeMs: entry.mtimeMs, isCold: isCold,
+                        coldCutoffMs: coldCutoffMs, nowMs: nowMs)
                 }
+            }
+        }
+
+        if !isFullScan {
+            // Iterating the dictionary copies it, so processFile is free to
+            // add and drop entries as it goes.
+            for (path, client) in activeFiles where !walked.contains(path) {
+                var sb = stat()
+                guard lstat(path, &sb) == 0, (sb.st_mode & S_IFMT) == S_IFREG else {
+                    // Deleted or replaced by a non-file; the next full scan
+                    // rediscovers it if it comes back.
+                    activeFiles[path] = nil
+                    continue
+                }
+                added += processFile(
+                    path: path, client: client, size: UInt64(max(sb.st_size, 0)),
+                    mtimeMs: statMtimeMs(sb), isCold: false,
+                    coldCutoffMs: coldCutoffMs, nowMs: nowMs)
             }
         }
 
         trimEvents()
         return added
+    }
+
+    /// Fold one observed (size, mtime) into the tail state, reading whatever
+    /// the file grew by. Shared between the walk and the active-file pass.
+    private func processFile(
+        path: String, client: TailClientKind, size: UInt64, mtimeMs: Int64,
+        isCold: Bool, coldCutoffMs: Int64, nowMs: Int64
+    ) -> Int {
+        if nowMs - mtimeMs <= activeFileWindowSecs * 1000 {
+            activeFiles[path] = client
+        } else {
+            activeFiles[path] = nil
+        }
+
+        let prev = files[path].map { ($0.offset, $0.mtimeMs) }
+
+        if isCold, prev == nil, mtimeMs < coldCutoffMs {
+            // Cold scan: stamp old files at EOF without reading
+            // (usage_tail.rs:175-179).
+            files[path] = .atEOF(size: size, mtimeMs: mtimeMs)
+            return 0
+        }
+
+        let startOffset = prev?.0 ?? 0
+        if size == startOffset {
+            // Preserve codex/grok thread state when only mtime refreshes
+            // without growth (:183-193). The offset already equals `size`
+            // here, so an unchanged mtime means there is nothing to write
+            // back — and skipping the write matters: this is the branch every
+            // dormant session file takes on every tick.
+            if let existing = files[path] {
+                if existing.mtimeMs != mtimeMs {
+                    files[path]!.mtimeMs = mtimeMs
+                }
+            } else {
+                files[path] = .atEOF(size: size, mtimeMs: mtimeMs)
+            }
+            return 0
+        }
+        if size < startOffset {
+            // Truncated / rotated log — drop threaded counters so we
+            // re-baseline instead of treating a new smaller total as a
+            // negative delta (:196-200).
+            files[path] = nil
+            return readGrowth(path: path, client: client,
+                              start: 0, end: size, mtimeMs: mtimeMs)
+        }
+        return readGrowth(path: path, client: client,
+                          start: startOffset, end: size, mtimeMs: mtimeMs)
     }
 
     // MARK: - Growth reads (usage_tail.rs:212-294)
@@ -724,3 +801,10 @@ func sidechainLabelFromPath(_ path: String) -> String {
     return "subagent:\(stem)"
 }
 
+private func statMtimeMs(_ sb: stat) -> Int64 {
+    // system_time_to_ms returns 0 for pre-epoch/errored mtimes.
+    let sec = Int64(sb.st_mtimespec.tv_sec)
+    let nsec = Int64(sb.st_mtimespec.tv_nsec)
+    if sec < 0 { return 0 }
+    return sec * 1000 + nsec / 1_000_000
+}

--- a/native/LocalPackage/Tests/CollectorTests/DirScanTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/DirScanTests.swift
@@ -61,6 +61,7 @@ struct DirScanTests {
 
         let entry = scanDirectory(dir.path).first { $0.name == "s.jsonl" }
         #expect(entry?.mtimeMs == 1_700_000_000_000)
+        #expect(entry?.mtimeNs == 1_700_000_000_000_000_000)
     }
 
     // Growth must be visible on the very next scan — this is the signal the

--- a/native/LocalPackage/Tests/CollectorTests/TailTieredScanTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/TailTieredScanTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+
+@testable import Collector
+
+// The tick walk is pruned by directory mtime and topped up by re-stat'ing
+// recently-touched files. These tests pin what each tier is responsible for,
+// and what falls through to the periodic full scan.
+struct TailTieredScanTests {
+    private func home(_ name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "tokcat-tiered-\(name)-\(ProcessInfo.processInfo.processIdentifier)-\(nowMs())")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent(".claude/projects/p"),
+            withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func assistantLine(_ msgId: String, input: Int) -> String {
+        """
+        {"type":"assistant","requestId":"r-\(msgId)","message":{"id":"\(msgId)","model":"m","usage":{"input_tokens":\(input),"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}
+
+        """
+    }
+
+    /// Appending to a file leaves its directory's mtime alone, so the pruned
+    /// walk skips that directory — the active-file pass is what carries the
+    /// live rate signal between full scans.
+    @Test func activeFileGrowthIsSeenOnAPrunedTick() async throws {
+        let root = try home("active")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let path = root.appendingPathComponent(".claude/projects/p/s.jsonl").path
+        try assistantLine("a", input: 10).write(toFile: path, atomically: true,
+                                                encoding: .utf8)
+
+        // A long interval means only the cold tick is a full walk; every tick
+        // after it is pruned.
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, fullScanIntervalMs: 3_600_000))
+        #expect(await tailer.tick() == 1)
+        #expect(await tailer.activeFiles[path] != nil)
+
+        let handle = FileHandle(forWritingAtPath: path)!
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(assistantLine("b", input: 20).utf8))
+        try handle.close()
+
+        #expect(await tailer.tick() == 1)
+        #expect(await tailer.eventsSnapshot().map(\.input) == [10, 20])
+    }
+
+    /// Creating a file DOES move its directory's mtime, so a brand-new session
+    /// must not wait for the full scan — this is the common case (a new agent
+    /// run) and the one a 60s delay would be felt in.
+    @Test func newFileIsFoundOnAPrunedTick() async throws {
+        let root = try home("newfile")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dir = root.appendingPathComponent(".claude/projects/p")
+
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, fullScanIntervalMs: 3_600_000))
+        #expect(await tailer.tick() == 0)  // cold, empty
+
+        try assistantLine("fresh", input: 33).write(
+            toFile: dir.appendingPathComponent("new.jsonl").path,
+            atomically: true, encoding: .utf8)
+
+        #expect(await tailer.tick() == 1)
+        #expect(await tailer.eventsSnapshot().map(\.input) == [33])
+    }
+
+    /// A whole new project directory appears under the root, which is always
+    /// walked — so the nested file is found without a full scan too.
+    @Test func newDirectoryIsFoundOnAPrunedTick() async throws {
+        let root = try home("newdir")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, fullScanIntervalMs: 3_600_000))
+        #expect(await tailer.tick() == 0)
+
+        let fresh = root.appendingPathComponent(".claude/projects/q/deeper")
+        try FileManager.default.createDirectory(at: fresh, withIntermediateDirectories: true)
+        try assistantLine("nested", input: 44).write(
+            toFile: fresh.appendingPathComponent("s.jsonl").path,
+            atomically: true, encoding: .utf8)
+
+        #expect(await tailer.tick() == 1)
+        #expect(await tailer.eventsSnapshot().map(\.input) == [44])
+    }
+
+    /// The documented gap: a file idle longer than the active window drops off
+    /// the watch list, and growth in it waits for the next unpruned walk. The
+    /// delta is delayed, never lost — readGrowth resumes from the stored
+    /// offset, so the event still carries its full token counts.
+    @Test func dormantFileGrowthWaitsForTheFullScan() async throws {
+        let root = try home("dormant")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let path = root.appendingPathComponent(".claude/projects/p/old.jsonl").path
+        try assistantLine("seed", input: 1).write(toFile: path, atomically: true,
+                                                  encoding: .utf8)
+
+        // In production the full scan (60s) comes round long before the active
+        // window (600s) expires, so the dormant gap is capped at 60s and can't
+        // be isolated. Stretch the interval here to exercise the gap itself.
+        let fullScanIntervalMs: Int64 = 3_600_000
+        let clock = TieredClock(now: nowMs())
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, nowMs: { clock.value },
+            fullScanIntervalMs: fullScanIntervalMs))
+        #expect(await tailer.tick() == 1)
+
+        // Push the clock past the active window and tick once: the file is
+        // still stat'd (it was on the watch list going in), finds no growth,
+        // and drops off on the way out.
+        clock.value += (activeFileWindowSecs + 60) * 1000
+        #expect(await tailer.tick() == 0)
+        #expect(await tailer.activeFiles[path] == nil)
+
+        // Now it is genuinely dormant. Appending moves the file's mtime but
+        // not its directory's, so the pruned walk skips the directory and
+        // nothing re-stats the file.
+        let handle = FileHandle(forWritingAtPath: path)!
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(assistantLine("late", input: 99).utf8))
+        try handle.close()
+        #expect(await tailer.tick() == 0)
+
+        // Next full scan picks the growth up in full.
+        clock.value += fullScanIntervalMs
+        #expect(await tailer.tick() == 1)
+        // The seed event has aged out of the 1h ring by now; what matters is
+        // that the deferred delta arrives whole rather than truncated.
+        #expect(await tailer.eventsSnapshot().map(\.input) == [99])
+    }
+
+    /// A file deleted out from under the active pass must not wedge the tick.
+    @Test func deletedActiveFileIsDroppedQuietly() async throws {
+        let root = try home("deleted")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let path = root.appendingPathComponent(".claude/projects/p/gone.jsonl").path
+        try assistantLine("x", input: 5).write(toFile: path, atomically: true,
+                                               encoding: .utf8)
+
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, fullScanIntervalMs: 3_600_000))
+        #expect(await tailer.tick() == 1)
+        #expect(await tailer.activeFiles[path] != nil)
+
+        try FileManager.default.removeItem(atPath: path)
+        #expect(await tailer.tick() == 0)
+        #expect(await tailer.activeFiles[path] == nil)
+    }
+
+    /// Pruning must not double-count: when a directory IS revisited, the file
+    /// it yields is also on the active list, and only one of the two paths may
+    /// read the growth.
+    @Test func walkAndActivePassDoNotDoubleRead() async throws {
+        let root = try home("dedup")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dir = root.appendingPathComponent(".claude/projects/p")
+        let path = dir.appendingPathComponent("s.jsonl").path
+        try assistantLine("a", input: 10).write(toFile: path, atomically: true,
+                                                encoding: .utf8)
+
+        let tailer = UsageTailer(config: UsageTailerConfig(
+            simulatedHome: root.path, fullScanIntervalMs: 3_600_000))
+        #expect(await tailer.tick() == 1)
+
+        // Grow the tracked file AND add a sibling, so the directory's mtime
+        // moves and the walk descends into it on the same tick.
+        let handle = FileHandle(forWritingAtPath: path)!
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(assistantLine("b", input: 20).utf8))
+        try handle.close()
+        try assistantLine("c", input: 30).write(
+            toFile: dir.appendingPathComponent("sibling.jsonl").path,
+            atomically: true, encoding: .utf8)
+
+        #expect(await tailer.tick() == 2)
+        #expect(await tailer.eventsSnapshot().map(\.input).sorted() == [10, 20, 30])
+    }
+}
+
+/// Mutable clock for the tiered-scan tests (@unchecked: single-threaded use).
+private final class TieredClock: @unchecked Sendable {
+    var value: Int64
+    init(now: Int64) { value = now }
+}

--- a/native/LocalPackage/Tests/CollectorTests/TailUsageTailerTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/TailUsageTailerTests.swift
@@ -296,8 +296,12 @@ private func grokLine(_ total: Int64, _ model: String?, _ tsMs: Int64) -> String
             [.modificationDate: Date(timeIntervalSinceNow: -7 * 3600)],
             ofItemAtPath: path)
 
+        // fullScanIntervalMs: 0 keeps every tick an unpruned walk. This test
+        // is about the cold-scan/shrink semantics, and the file it appends to
+        // is deliberately 7h old — exactly the dormant case the pruned walk
+        // defers to the next full scan (see tieredScan* below).
         let tailer = UsageTailer(
-            config: UsageTailerConfig(simulatedHome: home.path))
+            config: UsageTailerConfig(simulatedHome: home.path, fullScanIntervalMs: 0))
         let added = await tailer.tick()
         #expect(added == 0)  // stamped at EOF, never read
         let stampedOffset = await tailer.files[path]?.offset


### PR DESCRIPTION
Follow-up to #61. That one made each directory cheap to read; this one stops reading most of them.

## Why

After #61 the 5s tick still visited every session directory on the machine — ~1,000 of them, 12ms per walk, twelve times a minute — and almost all of that was re-confirming that dormant files had not moved.

## The observation

A directory's mtime moves when an entry is **created, removed or renamed** inside it. It does **not** move when a file it already holds simply grows. That splits the work:

| case | who catches it | latency |
|---|---|---|
| new session file / new project dir | pruned walk (parent's mtime moved) | ≤ 5s |
| growth in a recently-active file | active-file re-stat (last 10 min) | ≤ 5s |
| growth in a file dormant > 10 min | unpruned backstop walk | ≤ 60s |

The third row is the tradeoff: resuming a long-idle session registers up to a minute late. The delta is **delayed, never lost** — `readGrowth` resumes from the stored offset, so totals stay exact and the event carries its full token counts. Both rate windows are 60s/600s averages, so it isn't visible in the graph.

## Nanosecond directory mtimes

`DirEntryInfo` now carries `mtimeNs`, with `mtimeMs` derived from it. Millisecond truncation was not just imprecise, it was wrong: a directory changed twice inside one millisecond compared equal to its previous value, so a newly created file stayed invisible until the next full scan. This showed up as a flaky test before it showed up as a bug.

## Results

`tick()` over the real home, release build:

| | tick | per minute |
|---|---|---|
| before #61 | 73.3 ms | 879 ms |
| after #61 | 12.3 ms | 147 ms |
| **now** | **0.87 ms** pruned / 13.3 ms full | **23 ms** |

Whole app, 180s windows against RunCat on the same machine:

| | CPU |
|---|---|
| Tokcat (this branch) | **0.34%** |
| RunCat | 0.72% |
| Tokcat before #61 | 2.4% |

Verified against the live home that the tailer still tracks real usage (`added=1`, rate/min and per-client trace buckets updating) — the walk got cheaper, not blinder.

## Tests

169 pass, 5 runs clean. New `TailTieredScanTests` pins each tier's responsibility: active-file growth on a pruned tick, new file on a pruned tick, new nested directory on a pruned tick, the dormant-file gap and its backstop recovery, deleted-file cleanup, and walk/active-pass dedup.

`UsageTailerConfig.fullScanIntervalMs` makes the backstop injectable; `0` restores the old always-full walk, which is what the cold-scan test asserts against.