### PR TITLE
Release Tokcat 0.2.8

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.2.7
-        CURRENT_PROJECT_VERSION: 8
+        MARKETING_VERSION: 0.2.8
+        CURRENT_PROJECT_VERSION: 9
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump for the tick-walk energy work: #61 (bulk directory scanning) and #62 (directory-mtime pruning).

`MARKETING_VERSION` 0.2.7 → 0.2.8, `CURRENT_PROJECT_VERSION` 8 → 9 (Sparkle compares this one).

Idle CPU on a real machine: **2.4% → 0.34%**, against RunCat's 0.72% in the same window.