### PR TITLE
fix(tail): unblock the 0.3.0 release build

### DIFF
--- a/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
+++ b/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
@@ -504,10 +504,19 @@ public actor UsageTailer {
         if input + output + cacheRead + cacheWrite <= 0 { return false }
 
         let model = tailNormalizeModel(message["model"]?.asString ?? "unknown")
-        let tsMs =
-            strictI64(message["timestamp"]).map(normalizeEpochMs)
-            ?? value["timestamp"]?.asString.flatMap(rfc3339ToTimestampMs)
-            ?? now()
+        // Spelled out rather than chained through `map`/`??`: the autoclosure
+        // operands captured `value` alongside the actor-isolated `now()`, which
+        // the Release-configuration concurrency checker rejects as a send.
+        let tsMs: Int64
+        if let epochMs = strictI64(message["timestamp"]) {
+            tsMs = normalizeEpochMs(epochMs)
+        } else if let iso = value["timestamp"]?.asString,
+            let parsed = rfc3339ToTimestampMs(iso)
+        {
+            tsMs = parsed
+        } else {
+            tsMs = now()
+        }
         let responseId = message["responseId"]?.asString ?? ""
 
         return pushEvent(


### PR DESCRIPTION
The v0.3.0 release build failed in `Build universal app`: Release-configuration concurrency checking rejected the omp timestamp fallback (`sending 'value' risks causing data races`, UsageTailer.swift:509). `swift build` and the Debug app build do not surface it.

Reproduced locally with `xcodebuild -configuration Release` (fails before, succeeds after). No release was published for v0.3.0 — the tag will be re-cut on this commit.