### PR TITLE
Document the Claude issue-delegation harness in both READMEs

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -272,6 +272,16 @@ git push origin v<VERSION>
 
 ---
 
+## 이슈를 Claude에게 위임하기
+
+오너가 이슈에 `claude` 라벨을 붙이면 Claude Code 클라우드 세션이 그 이슈를 맡습니다. 이슈 내용과 저장소 문서를 함께 읽고, 요구사항이 부족하면 이슈에 질문을 남기며, 충분하면 `claude/issue-<N>` 브랜치에서 작업해 셀프 리뷰가 달린 PR을 엽니다.
+
+저절로 머지되는 일은 없습니다. Claude가 연 PR은 오너가 `approved` 라벨(또는 리뷰 **Approve**)로 승인해야 auto-merge가 켜지고, 그 뒤 필수 CI 체크가 모두 통과해야 `main`에 들어갑니다.
+
+이슈는 누구나 올릴 수 있지만, 이 흐름을 시작하는 라벨은 오너만 붙일 수 있습니다. 자세한 동작은 [`.claude/harness/README.md`](.claude/harness/README.md)를 참고하세요.
+
+---
+
 ## 관련 리포지토리
 
 | Repo | 역할 |

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -272,9 +272,9 @@ git push origin v<VERSION>
 
 ---
 
-## 이슈를 Claude에게 위임하기
+## Claude에게 이슈 위임하기
 
-오너가 이슈에 `claude` 라벨을 붙이면 Claude Code 클라우드 세션이 그 이슈를 맡습니다. 이슈 내용과 저장소 문서를 함께 읽고, 요구사항이 부족하면 이슈에 질문을 남기며, 충분하면 `claude/issue-<N>` 브랜치에서 작업해 셀프 리뷰가 달린 PR을 엽니다.
+오너가 이슈에 `claude` 라벨을 붙이면 Claude Code 클라우드 세션이 그 이슈를 맡습니다. 이슈 내용과 저장소 문서를 함께 읽고, 요구사항이 부족하면 이슈에 `claude:needs-info` 라벨을 붙이고 질문을 남기며, 충분하면 `claude/issue-<N>` 브랜치에서 작업해 셀프 리뷰가 달린 PR을 엽니다.
 
 저절로 머지되는 일은 없습니다. Claude가 연 PR은 오너가 `approved` 라벨(또는 리뷰 **Approve**)로 승인해야 auto-merge가 켜지고, 그 뒤 필수 CI 체크가 모두 통과해야 `main`에 들어갑니다.
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,16 @@ The workflow builds one ad-hoc-signed universal app, packages `Tokcat_<version>_
 
 ---
 
+## Delegating issues to Claude
+
+When the owner puts the `claude` label on an issue, a Claude Code cloud session picks it up: it reads the issue along with the repo docs, asks its questions on the issue itself when the requirements are too thin to implement, and otherwise works on a `claude/issue-<N>` branch and opens a pull request with a self-review note.
+
+Nothing lands on its own. A Claude pull request auto-merges only after the owner approves it — the `approved` label, or a review **Approve** — and even then only once the required CI checks are green.
+
+Anyone can file an issue; only the repository owner can apply the labels that start any of this. Full mechanics: [`.claude/harness/README.md`](.claude/harness/README.md).
+
+---
+
 ## Repos involved
 
 | Repo | Role |

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The workflow builds one ad-hoc-signed universal app, packages `Tokcat_<version>_
 
 ## Delegating issues to Claude
 
-When the owner puts the `claude` label on an issue, a Claude Code cloud session picks it up: it reads the issue along with the repo docs, asks its questions on the issue itself when the requirements are too thin to implement, and otherwise works on a `claude/issue-<N>` branch and opens a pull request with a self-review note.
+When the owner puts the `claude` label on an issue, a Claude Code cloud session picks it up: it reads the issue along with the repo docs, asks its questions on the issue itself and marks it `claude:needs-info` when the requirements are too thin to implement, and otherwise works on a `claude/issue-<N>` branch and opens a pull request with a self-review note.
 
 Nothing lands on its own. A Claude pull request auto-merges only after the owner approves it — the `approved` label, or a review **Approve** — and even then only once the required CI checks are green.
 


### PR DESCRIPTION
🤖 **Claude Code**

## Summary

`README.md`와 `README.ko-KR.md`에 Claude harness 안내 섹션을 추가했습니다. 이슈 #71에서 지정한 위치·내용 그대로이며, 문서 두 개 외에는 아무 파일도 건드리지 않았습니다.

## Changes

- `README.md` — `## Repos involved` 바로 앞에 `## Delegating issues to Claude` 섹션 추가 (3문단)
- `README.ko-KR.md` — `## 관련 리포지토리` 바로 앞에 `## 이슈를 Claude에게 위임하기` 섹션 추가 (영문판과 1:1 대응)

두 섹션이 담은 내용:
1. 오너가 `claude` 라벨을 붙이면 클라우드 세션이 이슈를 맡고, 요구사항이 부족하면 이슈에 질문을 남기며, 충분하면 `claude/issue-<N>` 브랜치에서 작업해 셀프 리뷰가 달린 PR을 연다
2. 오너 승인(`approved` 라벨 또는 리뷰 **Approve**) + 필수 CI 통과가 있어야만 auto-merge로 `main`에 들어간다
3. 이슈는 누구나 올릴 수 있지만 라벨은 오너만 붙인다
4. 상세는 [`.claude/harness/README.md`](.claude/harness/README.md) 상대 경로 링크

## Assumptions

- **문단 형식**: "각 3–5줄"을 불릿이 아니라 3문단 산문으로 풀었습니다. 인접한 `## Repos involved` / `## Acknowledgements`가 표·산문 위주라 불릿 목록보다 주변과 잘 붙습니다.
- **섹션 구분선**: 새 섹션 뒤에 `---`를 넣어 README 전체의 `섹션 → --- → 섹션` 패턴을 유지했습니다.
- **제목 언어**: 커밋 제목과 PR 제목은 기존 히스토리(영문 명령형)를 따랐고, 본문은 이슈 언어인 한국어로 썼습니다.
- **`claude/issue-<N>`** 표기를 그대로 노출했습니다. `.claude/harness/README.md`에서 쓰는 표기와 같습니다.

## How to verify

- `git diff main...claude/issue-71 --stat` → `README.md`, `README.ko-KR.md` 두 파일 `+10`씩, 그 외 변경 없음
- GitHub의 렌더된 README에서 새 섹션이 각각 `## Repos involved` / `## 관련 리포지토리` 바로 위에 오는지 확인
- 두 섹션의 `.claude/harness/README.md` 링크 클릭 → 저장소 상대 경로로 해당 파일이 열림 (링크 대상 존재 확인 완료)
- 영문/한글 섹션의 세 문단이 같은 내용을 담는지 나란히 비교

CI: 코드 변경이 없어 `Swift build + test` / `Rust check` / `Frontend typecheck` 세 잡 모두 기존과 동일하게 통과해야 합니다. 이 PR이 세 잡의 결과를 바꿀 이유는 없습니다.

## Risks / follow-ups

- 리스크 없음 — 마크다운 산문만 추가했고 기존 문구는 한 줄도 수정하지 않았습니다.
- 후속: 라벨 이름(`approved`, `claude:needs-info` 등)이나 머지 게이트 방식이 바뀌면 이 두 섹션과 `.claude/harness/README.md`를 함께 갱신해야 합니다. 지금은 README가 상세를 복제하지 않고 링크만 걸어 두었으므로 갱신 지점은 harness README 한 곳입니다.
- `README.ko-KR.md`에는 영문판의 `## Find Tokcat by use case`에 대응하는 섹션이 원래 없습니다. 이번 이슈 범위 밖이라 그대로 두었습니다.

Closes #71

<!-- claude-harness kind=DISPATCH issue=71 -->


---
_Generated by [Claude Code](https://claude.ai/code/session_014rBZWSJ5KV8TzstZ6pJgdE)_