### PR TITLE
harness: close linked issue on merge, grant issues:write to the gate

### DIFF
--- a/.claude/harness/README.md
+++ b/.claude/harness/README.md
@@ -35,7 +35,7 @@
 | --- | --- |
 | `.github/workflows/claude-dispatch.yml` | `issues.labeled(claude)` → 세션 발화 + 링크 코멘트. `workflow_dispatch`(DISPATCH/DRY_RUN)로 수동 실행 가능 |
 | `.github/workflows/claude-followup.yml` | 오너의 `@claude` 코멘트/리뷰 → 후속 세션. 시간당 3회 상한 |
-| `.github/workflows/claude-merge-gate.yml` | 오너 승인(리뷰 Approve / `approved` 라벨) → auto-merge. 라벨 제거 시 해제 |
+| `.github/workflows/claude-merge-gate.yml` | 오너 승인(리뷰 Approve / `approved` 라벨) → auto-merge. 라벨 제거·변경 요청·새 푸시 시 해제. 머지되면 연결 이슈를 닫고 라벨 정리 |
 | `scripts/claude-harness/build-payload.py` | 이슈/PR + 토론 + 문서·스펙을 한 텍스트로 조립 |
 | `scripts/claude-harness/fire.sh` | `/fire` 호출, 429/5xx 재시도, 세션 ID/URL 출력 |
 | `.claude/harness/ROUTINE_PROMPT.md` | 세션이 따르는 지침의 원본. 클론에 있으면 claude.ai에 저장된 사본보다 우선 |
@@ -65,8 +65,9 @@
 
 - **드라이런**: `gh workflow run claude-dispatch.yml -f issue_number=<N> -f kind=DRY_RUN` (또는
   로컬에서 `GH_REPO=handlecusion/tokcat scripts/claude-harness/build-payload.py --kind DRY_RUN --issue N > p.txt && scripts/claude-harness/fire.sh p.txt`).
-  세션이 이슈에 "harness dry run OK" 코멘트를 남기면 경로 전체가 살아 있는 것. (2026-08-30 #68로 검증 완료:
-  발화 → 세션 생성 → 클론 → owner로 인증 → 서명 코멘트.)
+  세션이 이슈에 "harness dry run OK" 코멘트를 남기면 경로 전체가 살아 있는 것.
+  (2026-08-30 E2E 검증: #70 DRY_RUN, #71→PR #72 — 라벨 → 세션 → PR+인라인 셀프 리뷰 → `@claude` 리뷰 반영 →
+  `approved` → auto-merge. 머지는 github-actions[bot]이 수행하므로 `issues: write` 없이는 `Closes #N`이 안 닫힌다.)
 - **재실행**: `claude:running`을 뗀 뒤, `claude` 라벨을 떼었다가 다시 붙인다(라벨 *추가* 이벤트가 트리거).
 - **질문 답변**: `claude:needs-info`가 붙어 있는 동안은 오너의 아무 코멘트나 후속 세션을 띄운다. 그 외에는
   코멘트/리뷰(인라인 코멘트 포함) 어딘가에 `@claude`가 있어야 한다. Claude 글을 Quote-reply 해도 된다.

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -21,11 +21,12 @@ on:
   pull_request_review:
     types: [submitted, dismissed]
   pull_request_target:
-    types: [labeled, unlabeled, synchronize]
+    types: [labeled, unlabeled, synchronize, closed]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write   # closing the linked issue on merge needs this (GITHUB_TOKEN otherwise leaves "Closes #N" unresolved)
 
 concurrency:
   group: claude-merge-gate-${{ github.event.pull_request.number }}
@@ -47,6 +48,10 @@ jobs:
       || (github.event_name == 'pull_request_target'
         && github.event.action == 'synchronize'
         && contains(github.event.pull_request.labels.*.name, 'approved'))
+      || (github.event_name == 'pull_request_target'
+        && github.event.action == 'closed'
+        && github.event.pull_request.merged == true
+        && startsWith(github.event.pull_request.head.ref, 'claude/'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -73,6 +78,7 @@ jobs:
             pull_request_target/labeled/*)                   mode=approve ;;
             pull_request_target/unlabeled/*)                 mode=withdraw; why="approved 라벨이 제거" ;;
             pull_request_target/synchronize/*)               mode=withdraw; why="승인 뒤 새 커밋이 푸시" ;;
+            pull_request_target/closed/*)                    mode=finish ;;
           esac
           [ -n "$mode" ] || { echo "::error::unhandled $EVENT/$ACTION/$REVIEW_STATE"; exit 1; }
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
@@ -137,6 +143,28 @@ jobs:
               -f body="$(printf '✋ **Claude harness** — %s되어 승인을 해제했습니다(approved 라벨 제거, 자동 머지 해제). 다시 검토한 뒤 승인해 주세요.\n\n<!-- claude-harness kind=MERGE_GATE issue=%s -->' "$WHY" "$PR")" --silent
           else
             echo "nothing to withdraw"
+          fi
+
+      - name: Merged → close the linked issue and clear harness labels
+        if: steps.decide.outputs.mode == 'finish'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          issue=$(printf '%s' "$PR_BODY" | grep -oE 'claude-harness[^>]*issue=[0-9]+' | grep -oE '[0-9]+$' | head -1)
+          [ -n "$issue" ] || issue=$(printf '%s' "$HEAD_REF" | grep -oE 'issue-[0-9]+$' | grep -oE '[0-9]+')
+          [ -n "$issue" ] || { echo "no linked issue found in PR body/branch — nothing to close"; exit 0; }
+          state=$(gh api "repos/$GH_REPO/issues/$issue" --jq .state)
+          for l in 'claude%3Apr-open' 'claude%3Arunning' 'claude%3Aneeds-info'; do
+            gh api -X DELETE "repos/$GH_REPO/issues/$issue/labels/$l" --silent 2>/dev/null || true
+          done
+          if [ "$state" = "open" ]; then
+            gh api -X POST "repos/$GH_REPO/issues/$issue/comments" \
+              -f body="$(printf '✅ **Claude harness** — PR #%s가 main에 머지되어 이 이슈를 닫습니다.\n\n<!-- claude-harness kind=MERGE_GATE issue=%s -->' "$PR" "$issue")" --silent
+            gh api -X PATCH "repos/$GH_REPO/issues/$issue" -f state=closed -f state_reason=completed --silent
+            echo "closed #$issue"
+          else
+            echo "#$issue already $state"
           fi
 
       - name: Report failure on the PR


### PR DESCRIPTION
Follow-up from the E2E run (#71 → #72): the merge was performed by github-actions[bot] whose token lacked `issues: write`, so `Closes #71` did not close the issue. Adds the permission and an explicit close-on-merge step keyed on the harness marker; clears `claude:*` labels.