### PR TITLE
feat(live): poll Cursor aggregated usage into the Live session card

### DIFF
--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -61,8 +61,8 @@ brew install --cask handlecusion/tokcat/tokcat
 | **한눈에** | 메뉴바 타이틀에 표시할 항목을 선택할 수 있음 — 오늘의 토큰 / 오늘의 비용 / 전체 토큰 / 전체 비용 / tokens per min / 플랜 사용률 / 아이콘만. |
 | **네이티브** | 전부 Swift + SwiftUI. macOS `NSVisualEffectView` 비브런시, 시스템 폰트, 3D 그래프는 SceneKit, 라이트/다크는 시스템 설정을 따름. 웹뷰도 JS 런타임도 없음. |
 | **조용함** | 메뉴바에만 상주 — Dock 아이콘 없음, 잡 알림 없음, 다른 앱 클릭 시 자동 hide. |
-| **정직함** | 사용량 히스토리는 로컬 세션 로그를 기기 안에서 읽어 산출. 텔레메트리·분석·클라우드 동기화·Tokcat 계정 없음. |
-| **다중 클라이언트** | Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi 로그 지원. |
+| **정직함** | 사용량 히스토리는 로컬 세션 로그를 기기 안에서 읽어 산출. Cursor는 Settings → Cursor usage 옵트인 시에만 cursor.com에서 가져온다. 텔레메트리·분석·클라우드 동기화·Tokcat 계정 없음. |
+| **다중 클라이언트** | Claude Code, Codex CLI, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi 로그와 옵트인 Cursor usage 지원. |
 | **고양이** | 메뉴바 고양이가 당신의 토큰을 받아먹고 더 많이 소화할수록 빠르게 회전합니다 — 한 마리 생물로 표현된 토큰 처리량. |
 
 ---
@@ -130,7 +130,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 | **인앱 자동 업데이트** | Sparkle 2 + EdDSA 서명 appcast. 시작 시 + 1시간마다 silent 체크, 트레이 메뉴의 "Check for Updates…"로 수동 체크. |
 | **로그인 시 자동 실행** | macOS `SMAppService` — Settings에서 활성화하며, 시스템 설정 → 로그인 항목의 실제 상태와 자동으로 맞춰집니다. |
 | **스트릭 & 요약** | 최장/현재 스트릭, 누적 토큰, 누적 비용, 일평균, 최고 사용일. |
-| **텔레메트리 없음** | 사용량 히스토리는 로컬에 머무릅니다. 네트워크 요청은 서명된 업데이트 확인과 credential이 있을 때의 Codex/Claude/Grok/Cursor quota 조회로 제한됩니다. |
+| **텔레메트리 없음** | 사용량 히스토리는 로컬에 머무릅니다. 네트워크 요청은 서명된 업데이트 확인, credential이 있을 때의 Codex/Claude/Grok/Cursor quota 조회, 그리고 옵트인 Cursor usage(히스토리 백필 + 라이브 폴링)로 제한됩니다. |
 
 ---
 
@@ -159,7 +159,7 @@ Settings에서 두 가지 스타일 선택 가능: 회전하는 고양이 또는
 |---|---|
 | Menubar title | 메뉴바 아이콘 옆에 표시할 텍스트 종류 (tokens per min, 플랜 사용률 포함) |
 | Plan source | 타이틀을 플랜 사용률로 뒀을 때 표시 — 어느 provider(Auto, Claude, Codex, Grok, Cursor)의 어느 window를 고정할지, % used인지 % left인지 |
-| Cursor usage → Fetch from cursor.com | 기본 꺼짐. 켜면 cursor.com에서 이벤트 단위 히스토리를 채워 넣고 Cursor 탭이 생깁니다 |
+| Cursor usage → Fetch from cursor.com | 기본 꺼짐. 켜면 cursor.com에서 이벤트 단위 히스토리를 채워 넣고 Cursor 탭이 생기며, Live session용 라이브 사용량도 폴링합니다. Cursor IDE와 Cursor CLI가 둘 다 꺼져 있으면 폴링을 멈춥니다. |
 | Launch at login | 로그인 시 Tokcat 자동 시작 (`SMAppService`) |
 | Menubar icon → Animate based on token usage | 회전하는 고양이 / party parrot 애니메이션 (토큰 처리량에 비례한 속도) |
 | Live trace → Split by agent / model | Live trace 카드를 클라이언트 한 줄에서 agent·model별 줄로 확장 |
@@ -198,7 +198,7 @@ Cursor는 예외입니다. Settings → Cursor usage → Fetch from cursor.com�
 
 ### Tokcat이 뭔가요?
 
-Tokcat은 AI 코딩 도구의 토큰 사용량을 2D 누적 차트와 3D GitHub 스타일 컨트리뷰션 그래프로 시각화해주는 무료 오픈소스 macOS 메뉴바 앱입니다. Swift와 SwiftUI로 작성됐고, Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi 세션을 로컬 로그에서 읽어 한 화면에 보여줍니다. 분석 요청을 보내지 않고, Tokcat 계정도 필요 없습니다. MIT 라이선스로 공개되어 있으며, Homebrew(`brew install --cask handlecusion/tokcat/tokcat`) 또는 GitHub Releases의 universal DMG로 배포됩니다. **Apple Silicon 및 Intel Mac, macOS 13 이상** 대상입니다.
+Tokcat은 AI 코딩 도구의 토큰 사용량을 2D 누적 차트와 3D GitHub 스타일 컨트리뷰션 그래프로 시각화해주는 무료 오픈소스 macOS 메뉴바 앱입니다. Swift와 SwiftUI로 작성됐고, Claude Code, Codex CLI, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi 세션을 로컬 로그에서 읽고, Cursor는 Settings → Cursor usage가 켜져 있을 때 cursor.com에서 가져와 한 화면에 보여줍니다. 분석 요청을 보내지 않고, Tokcat 계정도 필요 없습니다. MIT 라이선스로 공개되어 있으며, Homebrew(`brew install --cask handlecusion/tokcat/tokcat`) 또는 GitHub Releases의 universal DMG로 배포됩니다. **Apple Silicon 및 Intel Mac, macOS 13 이상** 대상입니다.
 
 ### 비용이 얼마인가요?
 
@@ -206,11 +206,11 @@ Tokcat은 MIT 라이선스 무료 오픈소스입니다. 구독, 유료 등급, 
 
 ### 어떤 AI 코딩 도구를 추적하나요?
 
-로컬 로그 기준으로 **Claude Code, OpenAI Codex CLI, Cursor IDE, OpenCode, Google Gemini CLI, GitHub Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi**를 추적합니다. 새 클라이언트 포맷은 Swift `Collector` 모듈에 파서로 추가됩니다.
+로컬 로그 기준으로 **Claude Code, OpenAI Codex CLI, OpenCode, Google Gemini CLI, GitHub Copilot CLI, Amp, Droid, Hermes, Grok Build, Oh My Pi**를 추적하고, **Cursor IDE**는 Settings → Cursor usage가 켜져 있을 때 추적합니다. 새 클라이언트 포맷은 Swift `Collector` 모듈에 파서로 추가됩니다.
 
 ### Tokcat은 제 데이터를 어디로 보내나요?
 
-Tokcat 서버로 사용량 히스토리를 보내지 않고, 텔레메트리·분석·클라우드 동기화·Tokcat 계정이 없습니다. 네트워크 요청은 Sparkle 업데이트 확인을 위한 `https://github.com/handlecusion/tokcat/releases/latest/download/appcast.xml` 조회와, 로컬 credential이 있을 때 Codex/Claude/Grok/Cursor quota를 직접 조회하는 요청으로 제한됩니다. 토큰 사용 히스토리는 디스크의 세션 로그에서 로컬로 읽습니다.
+Tokcat 서버로 사용량 히스토리를 보내지 않고, 텔레메트리·분석·클라우드 동기화·Tokcat 계정이 없습니다. 네트워크 요청은 Sparkle 업데이트 확인을 위한 `https://github.com/handlecusion/tokcat/releases/latest/download/appcast.xml` 조회, 로컬 credential이 있을 때 Codex/Claude/Grok/Cursor quota를 직접 조회하는 요청, 그리고 Settings → Cursor usage가 켜져 있을 때의 Cursor 히스토리 백필과 라이브 집계 폴링으로 제한됩니다. 다른 클라이언트의 토큰 사용 히스토리는 디스크의 세션 로그에서 로컬로 읽습니다.
 
 ### CLI 토큰 사용량 도구와 어떻게 다른가요?
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Tokcat is built for the category searches people actually type when AI coding bi
 | **Glanceable** | The menu bar title is configurable: today's tokens, today's cost, total tokens, total cost, live tokens/min, plan usage percent, or icon-only. |
 | **Native** | Swift and SwiftUI end to end — `NSVisualEffectView` vibrancy, system fonts, SceneKit for the 3D graph, and light/dark adaptation from the system appearance. No web view, no JavaScript runtime. |
 | **Quiet** | Lives in the menu bar — no Dock icon, no spurious notifications, auto-hides when you click another app. |
-| **Honest** | Usage history comes from local session logs read on-device. No telemetry, no analytics, no cloud sync, no Tokcat account. |
-| **Multi-client** | Tokcat reads Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi logs. |
+| **Honest** | Usage history comes from local session logs read on-device, except opt-in Cursor usage from cursor.com. No telemetry, no analytics, no cloud sync, no Tokcat account. |
+| **Multi-client** | Tokcat reads Claude Code, Codex CLI, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi logs, plus opt-in Cursor usage. |
 | **Cat** | The menubar cat eats your tokens and spins faster the more it digests — your token throughput as a single, glanceable critter. |
 
 ---
@@ -85,7 +85,7 @@ Tokcat is built for the category searches people actually type when AI coding bi
 
 Tokcat reads local usage logs in-process from its Swift collector layer. On demand from the tray menu, and on a 30-minute background refresh for the popover chart, it scans supported client stores, deduplicates streaming retries, normalizes token fields, estimates cost from a bundled model-price table when the source log does not include cost, and caches the graph payload in memory and on disk.
 
-For live activity, a JSONL tailer tracks recent growth in supported session logs and turns it into a 10-minute tokens/min signal. The same signal can drive the menu-bar title, the Live session card, and the adaptive tray animation.
+For live activity, a JSONL tailer tracks recent growth in supported session logs and turns it into a 10-minute tokens/min signal. Cursor has no local billed-token ledger, so the same Live session card can also include Cursor when Settings → Cursor usage is on: Tokcat polls Cursor's aggregated usage endpoint on an adaptive interval (15–120s, 300s after repeated 429s, paused when Cursor IDE and Cursor CLI are both quit) and diffs the totals. The same signal can drive the menu-bar title, the Live session card, and the adaptive tray animation.
 
 For agent-limit cards, Tokcat reads existing Codex, Claude, and Grok Build OAuth credentials plus Cursor's local session token, and asks those vendors' usage endpoints for quota windows. Those direct vendor calls are separate from the local usage history and are not telemetry.
 
@@ -149,7 +149,7 @@ Pick between two styles in Settings: the spinning cat or a party parrot. During 
 | **Launch at login** | macOS `SMAppService` — opt-in via Settings, and the toggle reconciles itself with System Settings → Login Items. |
 | **Live session** | 10-minute tokens/min breakdown by client, with an optional split by agent and model. |
 | **Streaks & summaries** | Longest / current streak, total tokens, total cost, daily average, best day. |
-| **No telemetry** | Usage history stays local. Network calls are limited to signed update checks and direct Codex/Claude/Grok quota lookups when credentialed. |
+| **No telemetry** | Usage history stays local. Network calls are limited to signed update checks, direct Codex/Claude/Grok/Cursor quota lookups when credentialed, and opt-in Cursor usage (history backfill plus live polling). |
 
 ---
 
@@ -178,7 +178,7 @@ After installation, launch **Tokcat** from `/Applications`. Click the cat in the
 |---|---|
 | Menubar title | What the menu-bar text shows next to the icon, including live tokens/min and plan usage percent. |
 | Plan source | Shown when the title is set to plan usage: which provider (Auto, Claude, Codex, Grok, Cursor) and which quota window to pin, and whether to show % used or % left. |
-| Cursor usage → Fetch from cursor.com | Off by default. When on, Tokcat backfills per-event Cursor history from cursor.com and gives Cursor its own tab. |
+| Cursor usage → Fetch from cursor.com | Off by default. When on, Tokcat backfills per-event Cursor history from cursor.com, gives Cursor its own tab, and polls live usage for the Live session card. Polling pauses when Cursor IDE and Cursor CLI are both quit. |
 | Launch at login | Starts Tokcat automatically when you log in (`SMAppService`). |
 | Menubar icon → Animate based on token usage | Spinning cat or party parrot animation that reflects token velocity. |
 | Live trace → Split by agent / model | Expands the Live trace card from one row per client into per-agent and per-model rows. |
@@ -201,7 +201,7 @@ Cursor is a special case: its tab only appears while Settings → Cursor usage �
 
 Limit cards use local OAuth credentials from Codex, Claude, and Grok Build. Run `codex login`, `claude`, or `grok login` to refresh those credentials, then choose Refresh Now. API-key-only Codex auth can still produce local token history, but OAuth usage limits require OAuth login. Cursor's card reads the session token Cursor stores locally — if it says the session expired, open Cursor and sign in again.
 
-Cursor's limit card is separate from Settings → Cursor usage. That toggle backfills the contribution graph with per-event history from cursor.com; the plan percentage needs no toggle.
+Cursor's limit card is separate from Settings → Cursor usage. That toggle backfills the contribution graph with per-event history from cursor.com and enables live-session polling; the plan percentage needs no toggle.
 
 **The menu-bar window vanishes when I click anywhere**
 
@@ -242,7 +242,7 @@ Tokcat 0.2.0 and later require macOS 13 (Ventura). On macOS 11 or 12, stay on `v
 
 ### What is Tokcat?
 
-Tokcat is a free, open-source native macOS menu-bar app that visualizes your AI coding token usage as a 2D stacked chart and 3D GitHub-style contribution graph. Written in Swift and SwiftUI, it reads local sessions from Claude Code, Codex CLI, Cursor IDE, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi in one glanceable place. Tokcat makes zero analytics requests, requires no Tokcat account, and reads token history from local session logs. The app is MIT-licensed, distributed via Homebrew (`brew install --cask handlecusion/tokcat/tokcat`) and as a universal DMG from GitHub Releases, and runs on Apple Silicon and Intel Macs with macOS 13 or newer.
+Tokcat is a free, open-source native macOS menu-bar app that visualizes your AI coding token usage as a 2D stacked chart and 3D GitHub-style contribution graph. Written in Swift and SwiftUI, it reads local sessions from Claude Code, Codex CLI, OpenCode, Gemini CLI, Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi, plus opt-in Cursor usage from cursor.com, in one glanceable place. Tokcat makes zero analytics requests, requires no Tokcat account, and reads token history from local session logs except for that Cursor opt-in. The app is MIT-licensed, distributed via Homebrew (`brew install --cask handlecusion/tokcat/tokcat`) and as a universal DMG from GitHub Releases, and runs on Apple Silicon and Intel Macs with macOS 13 or newer.
 
 ### How much does Tokcat cost?
 
@@ -250,11 +250,11 @@ Tokcat is free and open-source under the MIT licence. There is no subscription, 
 
 ### Which AI coding tools does Tokcat track?
 
-Tokcat tracks **Claude Code, OpenAI Codex CLI, Cursor IDE, OpenCode, Google Gemini CLI, GitHub Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi** from local logs. New client formats are added as parsers in Tokcat's Swift `Collector` module.
+Tokcat tracks **Claude Code, OpenAI Codex CLI, OpenCode, Google Gemini CLI, GitHub Copilot CLI, Amp, Droid, Hermes, Grok Build, and Oh My Pi** from local logs, and **Cursor IDE** when Settings → Cursor usage is on. New client formats are added as parsers in Tokcat's Swift `Collector` module.
 
 ### Does Tokcat send my data anywhere?
 
-Tokcat does not send usage history to Tokcat servers and has no telemetry, analytics, cloud sync, or Tokcat account. It does make network requests for two explicit product functions: Sparkle update checks against `https://github.com/handlecusion/tokcat/releases/latest/download/appcast.xml`, and direct Codex/Claude/Grok/Cursor quota lookups against those vendors when local credentials are available. Token-usage history is read locally from session logs.
+Tokcat does not send usage history to Tokcat servers and has no telemetry, analytics, cloud sync, or Tokcat account. It does make network requests for three explicit product functions: Sparkle update checks against `https://github.com/handlecusion/tokcat/releases/latest/download/appcast.xml`; direct Codex/Claude/Grok/Cursor quota lookups against those vendors when local credentials are available; and, when Settings → Cursor usage is on, Cursor history backfill plus live aggregated-usage polls. Token-usage history for every other client is read locally from session logs.
 
 ### How is Tokcat different from CLI token-usage tools?
 

--- a/native/LocalPackage/Sources/Collector/CursorFetch/CursorAggregate.swift
+++ b/native/LocalPackage/Sources/Collector/CursorFetch/CursorAggregate.swift
@@ -1,0 +1,341 @@
+import Foundation
+
+// Snapshot + diff for Cursor's DashboardService/GetAggregatedUsageEvents.
+//
+// Cursor keeps no local billed-token ledger. The aggregated endpoint returns
+// monotonically growing totals for a pinned window (verified: 59 diffs / 0
+// decreases over 10 minutes). Live rate is the Hermes pattern: first
+// observation is a silent baseline, later ticks emit per-model positive
+// deltas attributed to "now".
+
+let tailClientCursor = "cursor"
+
+/// Per-counter ceiling so four-way sums (duplicate merge, delta total,
+/// `UsageEvent.total`) cannot trap Int64 `+`. 10^15 is far above billed
+/// usage and below `Int64.max / 4`. Window aggregates still saturate via
+/// `satAdd` — event count is unbounded.
+let cursorTokenFieldMax: Int64 = 1_000_000_000_000_000
+
+/// Per-model token totals from one aggregated-usage response.
+public struct CursorModelTotals: Equatable, Sendable {
+    public var input: Int64
+    public var output: Int64
+    public var cacheWrite: Int64
+    public var cacheRead: Int64
+
+    public init(input: Int64 = 0, output: Int64 = 0,
+                cacheWrite: Int64 = 0, cacheRead: Int64 = 0) {
+        self.input = input
+        self.output = output
+        self.cacheWrite = cacheWrite
+        self.cacheRead = cacheRead
+    }
+
+    func decreasing(versus previous: CursorModelTotals) -> Bool {
+        input < previous.input
+            || output < previous.output
+            || cacheWrite < previous.cacheWrite
+            || cacheRead < previous.cacheRead
+    }
+}
+
+/// One poll of GetAggregatedUsageEvents, keyed by `modelIntent`.
+public struct CursorAggregateSnapshot: Equatable, Sendable {
+    public var models: [String: CursorModelTotals]
+    public var accountKey: String?
+
+    public init(models: [String: CursorModelTotals] = [:], accountKey: String? = nil) {
+        self.models = models
+        self.accountKey = accountKey
+    }
+
+    public static let empty = CursorAggregateSnapshot()
+
+    public var asPayload: CursorAggregatePayload {
+        CursorAggregatePayload(
+            models: models.mapValues {
+                CursorModelPartial(
+                    input: $0.input, output: $0.output,
+                    cacheWrite: $0.cacheWrite, cacheRead: $0.cacheRead)
+            },
+            accountKey: accountKey)
+    }
+}
+
+/// Wire-shape of one poll: missing counters stay nil so protobuf-style
+/// omitted zeros are not treated as decreases against the previous mark.
+public struct CursorModelPartial: Equatable, Sendable {
+    public var input: Int64?
+    public var output: Int64?
+    public var cacheWrite: Int64?
+    public var cacheRead: Int64?
+
+    public init(input: Int64? = nil, output: Int64? = nil,
+                cacheWrite: Int64? = nil, cacheRead: Int64? = nil) {
+        self.input = input
+        self.output = output
+        self.cacheWrite = cacheWrite
+        self.cacheRead = cacheRead
+    }
+
+    var hasAnyField: Bool {
+        input != nil || output != nil || cacheWrite != nil || cacheRead != nil
+    }
+
+    func resolved(over previous: CursorModelTotals?) -> CursorModelTotals {
+        CursorModelTotals(
+            input: input ?? previous?.input ?? 0,
+            output: output ?? previous?.output ?? 0,
+            cacheWrite: cacheWrite ?? previous?.cacheWrite ?? 0,
+            cacheRead: cacheRead ?? previous?.cacheRead ?? 0)
+    }
+
+    func merging(_ other: CursorModelPartial) throws -> CursorModelPartial {
+        CursorModelPartial(
+            input: try sumOpt(input, other.input),
+            output: try sumOpt(output, other.output),
+            cacheWrite: try sumOpt(cacheWrite, other.cacheWrite),
+            cacheRead: try sumOpt(cacheRead, other.cacheRead))
+    }
+}
+
+private func sumOpt(_ a: Int64?, _ b: Int64?) throws -> Int64? {
+    switch (a, b) {
+    case (nil, nil): return nil
+    case (let x?, nil): return x
+    case (nil, let y?): return y
+    case (let x?, let y?):
+        let (sum, overflow) = x.addingReportingOverflow(y)
+        if overflow || sum > cursorTokenFieldMax {
+            throw QuotaError("decode Cursor aggregate usage: token field overflow")
+        }
+        return sum
+    }
+}
+
+public struct CursorAggregatePayload: Equatable, Sendable {
+    public var models: [String: CursorModelPartial]
+    public var accountKey: String?
+
+    public init(models: [String: CursorModelPartial] = [:], accountKey: String? = nil) {
+        self.models = models
+        self.accountKey = accountKey
+    }
+}
+
+/// Diffs successive snapshots into live-ring events. The first consume is
+/// always a baseline (no events), matching Hermes `isCold`.
+public struct CursorAggregateDiffer: Equatable, Sendable {
+    public private(set) var baseline: CursorAggregateSnapshot?
+    /// True after a consume that adopted a new baseline without emitting
+    /// (first poll, or a confirmed billing-cycle / account reset).
+    public private(set) var didRebaseline = false
+    /// A one-poll decrease is held, not adopted. A second consecutive
+    /// decrease confirms rollover; a recovery against the original
+    /// baseline emits only the real delta (not the whole window).
+    var awaitingDecreaseConfirm = false
+
+    public init(baseline: CursorAggregateSnapshot? = nil) {
+        self.baseline = baseline
+    }
+
+    /// Resolve omitted counters against the current baseline, then consume.
+    public mutating func consume(
+        payload: CursorAggregatePayload, nowMs: Int64
+    ) -> [UsageEvent] {
+        var resolved = CursorAggregateSnapshot(accountKey: payload.accountKey)
+        var keys = Set(payload.models.keys)
+        if let baseline {
+            keys.formUnion(baseline.models.keys)
+        }
+        for key in keys {
+            resolved.models[key] = (payload.models[key] ?? CursorModelPartial())
+                .resolved(over: baseline?.models[key])
+        }
+        return consume(resolved, nowMs: nowMs)
+    }
+
+    /// Apply `current` and return events to ingest.
+    public mutating func consume(
+        _ current: CursorAggregateSnapshot, nowMs: Int64
+    ) -> [UsageEvent] {
+        didRebaseline = false
+        guard let previous = baseline else {
+            baseline = current
+            didRebaseline = true
+            awaitingDecreaseConfirm = false
+            return []
+        }
+
+        if snapshotDecreased(current, versus: previous) {
+            if awaitingDecreaseConfirm {
+                baseline = current
+                awaitingDecreaseConfirm = false
+                didRebaseline = true
+                return []
+            }
+            awaitingDecreaseConfirm = true
+            return []
+        }
+        awaitingDecreaseConfirm = false
+
+        var events: [UsageEvent] = []
+        let keys = Set(previous.models.keys).union(current.models.keys)
+        for key in keys.sorted() {
+            let prev = previous.models[key] ?? CursorModelTotals()
+            let next = current.models[key] ?? CursorModelTotals()
+            let dIn = next.input - prev.input
+            let dOut = next.output - prev.output
+            let dCW = next.cacheWrite - prev.cacheWrite
+            let dCR = next.cacheRead - prev.cacheRead
+            // Skip a delta that cannot be summed or ingested without trapping.
+            // Parse already rejects these; this guards constructed snapshots.
+            guard dIn <= cursorTokenFieldMax, dOut <= cursorTokenFieldMax,
+                  dCW <= cursorTokenFieldMax, dCR <= cursorTokenFieldMax,
+                  let delta = cursorCheckedSum(dIn, dOut, dCW, dCR),
+                  delta > 0
+            else { continue }
+            events.append(UsageEvent(
+                tsMs: nowMs, client: tailClientCursor, agent: "main",
+                model: tailNormalizeModel(key),
+                input: dIn, output: dOut, cacheRead: dCR, cacheWrite: dCW))
+        }
+        baseline = current
+        return events
+    }
+}
+
+func snapshotDecreased(
+    _ current: CursorAggregateSnapshot, versus previous: CursorAggregateSnapshot
+) -> Bool {
+    let keys = Set(previous.models.keys).union(current.models.keys)
+    for key in keys {
+        let prev = previous.models[key] ?? CursorModelTotals()
+        let next = current.models[key] ?? CursorModelTotals()
+        if next.decreasing(versus: prev) { return true }
+    }
+    return false
+}
+
+// MARK: - Parse
+
+/// Decode a Connect-JSON GetAggregatedUsageEvents body. Int64 fields may
+/// arrive as numbers or strings. Missing counters stay nil (omit-zero);
+/// a present field with a bad type or out-of-range number fails the poll
+/// so the previous baseline is held.
+public func parseCursorAggregateResponse(_ body: Data) throws -> CursorAggregatePayload {
+    guard let parsed = JSONValue.parse(body) else {
+        throw QuotaError("decode Cursor aggregate usage: invalid JSON")
+    }
+    return try parseCursorAggregateValue(parsed)
+}
+
+func parseCursorAggregateValue(_ parsed: JSONValue) throws -> CursorAggregatePayload {
+    let aggregationsNode = parsed["aggregations"]
+    let hasTopLevelTotals =
+        parsed["totalInputTokens"] != nil
+        || parsed["totalOutputTokens"] != nil
+        || parsed["totalCacheWriteTokens"] != nil
+        || parsed["totalCacheReadTokens"] != nil
+    if aggregationsNode == nil || aggregationsNode == .null {
+        if !hasTopLevelTotals {
+            throw QuotaError("decode Cursor aggregate usage: missing aggregations")
+        }
+    } else if aggregationsNode?.asArray == nil {
+        throw QuotaError("decode Cursor aggregate usage: aggregations is not an array")
+    }
+    var models: [String: CursorModelPartial] = [:]
+    for raw in aggregationsNode?.asArray ?? [] {
+        let name = raw["modelIntent"]?.asString ?? raw["model"]?.asString
+        let trimmed = name.map(rustTrim) ?? ""
+        let partial = try cursorModelPartial(from: raw)
+        if trimmed.isEmpty && !partial.hasAnyField {
+            throw QuotaError("decode Cursor aggregate usage: empty aggregation row")
+        }
+        let key = trimmed.isEmpty ? "cursor" : trimmed
+        if let existing = models[key] {
+            models[key] = try existing.merging(partial)
+        } else {
+            models[key] = partial
+        }
+    }
+    if models.isEmpty {
+        let partial = try cursorModelPartial(
+            input: parsed["totalInputTokens"],
+            output: parsed["totalOutputTokens"],
+            cacheWrite: parsed["totalCacheWriteTokens"],
+            cacheRead: parsed["totalCacheReadTokens"])
+        if partial.hasAnyField {
+            models["cursor"] = partial
+        }
+    }
+    return CursorAggregatePayload(models: models)
+}
+
+private func cursorModelPartial(from raw: JSONValue) throws -> CursorModelPartial {
+    try cursorModelPartial(
+        input: raw["inputTokens"],
+        output: raw["outputTokens"],
+        cacheWrite: raw["cacheWriteTokens"],
+        cacheRead: raw["cacheReadTokens"])
+}
+
+private func cursorModelPartial(
+    input: JSONValue?, output: JSONValue?,
+    cacheWrite: JSONValue?, cacheRead: JSONValue?
+) throws -> CursorModelPartial {
+    CursorModelPartial(
+        input: try cursorOptionalInt64(input),
+        output: try cursorOptionalInt64(output),
+        cacheWrite: try cursorOptionalInt64(cacheWrite),
+        cacheRead: try cursorOptionalInt64(cacheRead))
+}
+
+/// Absent key → nil. Present but unusable → throw (do not coerce to 0).
+/// Rejects negatives (including u64 bit-pattern wraps) and values above
+/// `cursorTokenFieldMax` so later `+` cannot trap.
+func cursorOptionalInt64(_ value: JSONValue?) throws -> Int64? {
+    guard let value else { return nil }
+    switch value {
+    case .null:
+        throw QuotaError("decode Cursor aggregate usage: null token field")
+    case .int(let i):
+        return try cursorAcceptTokenCount(i)
+    case .double(let d):
+        return try cursorAcceptTokenCount(fromDouble: d)
+    case .string(let s):
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        if let i = Int64(trimmed) { return try cursorAcceptTokenCount(i) }
+        if let d = Double(trimmed) { return try cursorAcceptTokenCount(fromDouble: d) }
+        throw QuotaError("decode Cursor aggregate usage: invalid token string")
+    default:
+        throw QuotaError("decode Cursor aggregate usage: token field has wrong type")
+    }
+}
+
+private func cursorAcceptTokenCount(_ i: Int64) throws -> Int64 {
+    guard i >= 0, i <= cursorTokenFieldMax else {
+        throw QuotaError("decode Cursor aggregate usage: token field out of range")
+    }
+    return i
+}
+
+private func cursorAcceptTokenCount(fromDouble d: Double) throws -> Int64 {
+    guard d.isFinite else {
+        throw QuotaError("decode Cursor aggregate usage: non-finite token field")
+    }
+    if d < 0 || d > Double(cursorTokenFieldMax) {
+        throw QuotaError("decode Cursor aggregate usage: token field out of range")
+    }
+    return Int64(d)
+}
+
+private func cursorCheckedSum(_ values: Int64...) -> Int64? {
+    var acc: Int64 = 0
+    for value in values {
+        let (next, overflow) = acc.addingReportingOverflow(value)
+        if overflow { return nil }
+        acc = next
+    }
+    return acc
+}

--- a/native/LocalPackage/Sources/Collector/CursorFetch/CursorAggregatedUsageFetcher.swift
+++ b/native/LocalPackage/Sources/Collector/CursorFetch/CursorAggregatedUsageFetcher.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// Connect RPC used by the live-session poller. Same auth shape as
+// CursorQuotaProvider (bearer + Connect-Protocol-Version) — not the
+// cookie/CSRF dashboard path used by the historical event cache.
+
+private let aggregatedUsageURL =
+    "https://api2.cursor.sh/aiserver.v1.DashboardService/GetAggregatedUsageEvents"
+private let dayMs: Int64 = 86_400_000
+
+public enum CursorAggregatedUsageFetcher {
+    /// Fetch one aggregated snapshot for `[startMs, endMs]`.
+    /// `endMs` should sit a day past "now" so in-flight events stay inside
+    /// the window; `startMs` must stay pinned across polls so the totals
+    /// remain a safe high-water mark.
+    public static func fetch(startMs: Int64, endMs: Int64) async throws -> CursorAggregatePayload {
+        let token: String
+        switch CursorState.readAccessToken() {
+        case .failure(let error): throw error
+        case .success(let value): token = value
+        }
+
+        var request = URLRequest(url: URL(string: aggregatedUsageURL)!)
+        request.timeoutInterval = 30
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Tokcat", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "teamId": 0,
+            "startDate": String(startMs),
+            "endDate": String(endMs),
+        ])
+
+        let status: Int
+        let body: Data
+        do {
+            (status, body) = try await QuotaHTTP.send(request)
+        } catch {
+            throw QuotaError("Cursor live usage request failed: \(error.localizedDescription)")
+        }
+        if status == 401 || status == 403 {
+            throw CursorLiveHTTPError.status(status)
+        }
+        if status == 429 {
+            throw CursorLiveHTTPError.status(429)
+        }
+        if !(200..<300).contains(status) {
+            throw CursorLiveHTTPError.status(status)
+        }
+        var payload = try parseCursorAggregateResponse(body)
+        // Non-secret JWT `sub` binds the baseline to one Cursor account so
+        // a mid-session account switch cannot look like a usage burst.
+        if let sub = try? CursorUsageFetcher.jwtSubject(token) {
+            payload.accountKey = sub
+        }
+        return payload
+    }
+
+    /// Default pinned lookback: six hours behind the first poll attempt.
+    /// Long enough to cover a working session; short enough that a cycle
+    /// rollover mid-run is still visible as a total decrease (rebaseline).
+    public static let pinnedLookbackMs: Int64 = 6 * 60 * 60 * 1000
+
+    public static func defaultEndMs(nowMs: Int64) -> Int64 {
+        nowMs + dayMs
+    }
+
+    public static func defaultStartMs(nowMs: Int64) -> Int64 {
+        nowMs - pinnedLookbackMs
+    }
+}
+
+/// Transport-level failures the poller uses to pick a backoff. 401/403
+/// suspend HTTP until Cursor is quit and relaunched (the token is re-read
+/// from state.vscdb on the next fetch). 429 means "slow down".
+public enum CursorLiveHTTPError: Error, Equatable, Sendable {
+    case status(Int)
+}

--- a/native/LocalPackage/Sources/Collector/CursorFetch/CursorLiveSchedule.swift
+++ b/native/LocalPackage/Sources/Collector/CursorFetch/CursorLiveSchedule.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// Adaptive poll cadence for Cursor live usage. 10s was the measurement
+// resolution, not the product interval.
+//
+//   Cursor IDE+CLI quit  → local re-check only (no HTTP)
+//   recent delta         → 15s
+//   idle ≥ 2 min         → 60s
+//   idle ≥ 10 min        → 120s
+//   HTTP 429             → 120s, then 300s while 429s continue
+//   HTTP 401/403         → provider suspends HTTP until Cursor is quit
+//                          and relaunched (token is re-read each fetch)
+
+public struct CursorLiveSchedule: Equatable, Sendable {
+    public static let activeSecs: TimeInterval = 15
+    public static let idleSecs: TimeInterval = 60
+    public static let idleLongSecs: TimeInterval = 120
+    public static let processCheckSecs: TimeInterval = 30
+    public static let rateLimitSecs: TimeInterval = 120
+    public static let rateLimitLongSecs: TimeInterval = 300
+    public static let idleAfterSecs: TimeInterval = 2 * 60
+    public static let longIdleAfterSecs: TimeInterval = 10 * 60
+
+    public var lastDeltaAt: Date?
+    public var startedAt: Date?
+    public var consecutive429: Int = 0
+
+    public init() {}
+
+    public mutating func noteSuccess(hadDelta: Bool, now: Date) {
+        consecutive429 = 0
+        if startedAt == nil { startedAt = now }
+        if hadDelta { lastDeltaAt = now }
+    }
+
+    public mutating func noteRateLimited() {
+        consecutive429 += 1
+    }
+
+    public func delay(now: Date, cursorRunning: Bool) -> TimeInterval {
+        if !cursorRunning { return Self.processCheckSecs }
+        if consecutive429 >= 2 { return Self.rateLimitLongSecs }
+        if consecutive429 >= 1 { return Self.rateLimitSecs }
+        let anchor = lastDeltaAt ?? startedAt ?? now
+        let idle = now.timeIntervalSince(anchor)
+        if idle < Self.idleAfterSecs { return Self.activeSecs }
+        if idle < Self.longIdleAfterSecs { return Self.idleSecs }
+        return Self.idleLongSecs
+    }
+}

--- a/native/LocalPackage/Sources/Collector/Support/Lenient.swift
+++ b/native/LocalPackage/Sources/Collector/Support/Lenient.swift
@@ -18,7 +18,7 @@ func rustAsI64(_ d: Double) -> Int64 {
     return Int64(d)
 }
 
-func satAdd(_ a: Int64, _ b: Int64) -> Int64 {
+public func satAdd(_ a: Int64, _ b: Int64) -> Int64 {
     let (r, overflow) = a.addingReportingOverflow(b)
     if overflow { return b > 0 ? Int64.max : Int64.min }
     return r

--- a/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
+++ b/native/LocalPackage/Sources/Collector/Tail/UsageTailer.swift
@@ -13,6 +13,8 @@ import Foundation
 // Grok Build:   $GROK_HOME/sessions/**/updates.jsonl
 // oh-my-pi:     ~/.omp/agent/sessions/**/*.jsonl (subagent transcripts are
 //               nested one level deeper, inside the parent session's dir)
+// Cursor:       no local ledger — Model's CursorLiveProvider diffs
+//               GetAggregatedUsageEvents and calls `ingest`.
 
 let tailClientClaude = "claude-code"
 let tailClientCodex = "codex-cli"
@@ -52,7 +54,21 @@ public struct UsageEvent: Codable, Equatable, Sendable {
         case cacheWrite = "cache_write"
     }
 
-    var total: Int64 { input + output + cacheRead + cacheWrite }
+    var total: Int64 {
+        satAdd(satAdd(input, output), satAdd(cacheRead, cacheWrite))
+    }
+
+    public init(tsMs: Int64, client: String, agent: String, model: String,
+                input: Int64, output: Int64, cacheRead: Int64, cacheWrite: Int64) {
+        self.tsMs = tsMs
+        self.client = client
+        self.agent = agent
+        self.model = model
+        self.input = input
+        self.output = output
+        self.cacheRead = cacheRead
+        self.cacheWrite = cacheWrite
+    }
 }
 
 /// Per-(client, agent, model) rollup over a trailing window
@@ -648,7 +664,11 @@ public actor UsageTailer {
 
     private func windowTotal(_ secs: Int64) -> Int64 {
         let cutoff = now() - secs * 1000
-        return events.lazy.filter { $0.tsMs >= cutoff }.map(\.total).reduce(0, +)
+        var total: Int64 = 0
+        for event in events where event.tsMs >= cutoff {
+            total = satAdd(total, event.total)
+        }
+        return total
     }
 
     /// Per-(client, agent, model) breakdown over `windowSecs`. The caller
@@ -661,7 +681,7 @@ public actor UsageTailer {
         for e in events where e.tsMs >= cutoff {
             let key = Key(client: e.client, agent: e.agent, model: e.model)
             var slot = groups[key] ?? (0, 0)
-            slot.tokens += e.total
+            slot.tokens = satAdd(slot.tokens, e.total)
             slot.messages += 1
             groups[key] = slot
         }
@@ -719,6 +739,25 @@ public actor UsageTailer {
     /// Snapshot of the raw event ring (for the tail-sim/tail-live dumps).
     public func eventsSnapshot() -> [UsageEvent] {
         events
+    }
+
+    /// Push already-diffed events into the ring. Used by network live
+    /// sources (Cursor) that cannot live inside `tick()` without breaking
+    /// the file-offset / `tailRoots()` contract. Empty `dedupKey` — the
+    /// caller owns uniqueness (snapshot diffs have no event id).
+    @discardableResult
+    public func ingest(_ incoming: [UsageEvent]) -> Int {
+        var added = 0
+        let cutoff = now() - eventWindowSecs * 1000
+        for event in incoming {
+            if event.total <= 0 { continue }
+            // Do not append already-expired rows: trimEvents wipes `seen`
+            // whenever it drops anything, which would break Claude dedup.
+            if event.tsMs < cutoff { continue }
+            if pushEvent(event, dedupKey: "") { added += 1 }
+        }
+        trimEvents()
+        return added
     }
 
     // MARK: - Roots (usage_tail.rs:728-773)

--- a/native/LocalPackage/Sources/Model/Logic/TraceCollapse.swift
+++ b/native/LocalPackage/Sources/Model/Logic/TraceCollapse.swift
@@ -75,7 +75,7 @@ public enum TraceCollapse {
                 agents[b.client] = []
                 models[b.client] = []
             }
-            tokens[b.client]! += b.tokens
+            tokens[b.client] = satAdd(tokens[b.client]!, b.tokens)
             messages[b.client]! += b.messages
             rates[b.client]! += b.tokensPerMin
             agents[b.client]!.insert(b.agent)

--- a/native/LocalPackage/Sources/Model/Stores/CursorLiveProvider.swift
+++ b/native/LocalPackage/Sources/Model/Stores/CursorLiveProvider.swift
@@ -1,0 +1,288 @@
+import AppKit
+import Collector
+import Darwin
+import Foundation
+
+// Polls Cursor's aggregated usage endpoint and pushes diffs into the
+// shared live-event ring. Separate from UsageTailer.tick — that actor
+// owns file offsets and must not grow a network source.
+//
+// Gated by the same `cursorUsage` opt-in as the historical event cache:
+// one consent covers every Cursor.com / api2.cursor.sh call. Polling
+// pauses while Cursor IDE and Cursor CLI are both quit and backs off
+// while the account is idle.
+
+public struct CursorProcessSnapshot: Sendable, Equatable {
+    public var running: Bool
+    public var pid: Int32?
+
+    public init(running: Bool, pid: Int32? = nil) {
+        self.running = running
+        self.pid = pid
+    }
+}
+
+public actor CursorLiveProvider {
+    public typealias Fetch = @Sendable (Int64, Int64) async throws -> CursorAggregatePayload
+    public typealias ProcessCheck = @Sendable () -> CursorProcessSnapshot
+    public typealias Clock = @Sendable () -> Date
+
+    private let tailer: UsageTailer
+    private let fetch: Fetch
+    private let processSnapshot: ProcessCheck
+    private let clock: Clock
+    private let nowMs: @Sendable () -> Int64
+
+    private var task: Task<Void, Never>?
+    private var differ = CursorAggregateDiffer()
+    private var schedule = CursorLiveSchedule()
+    private var windowStartMs: Int64?
+    private var accountKey: String?
+    /// 401/403: do not keep POSTing a dead token. Cleared on Cursor
+    /// relaunch (pid change) or when the opt-in is toggled off then on.
+    private var authSuspended = false
+    private var lastCursorPid: Int32?
+    private var appliedRevision: UInt64 = 0
+
+    public init(
+        tailer: UsageTailer,
+        fetch: Fetch? = nil,
+        processSnapshot: ProcessCheck? = nil,
+        clock: Clock? = nil,
+        nowMs: (@Sendable () -> Int64)? = nil
+    ) {
+        self.tailer = tailer
+        self.fetch = fetch ?? { start, end in
+            try await CursorAggregatedUsageFetcher.fetch(startMs: start, endMs: end)
+        }
+        self.processSnapshot = processSnapshot ?? { CursorProcess.snapshot() }
+        self.clock = clock ?? { Date() }
+        self.nowMs = nowMs ?? { Int64(Date().timeIntervalSince1970 * 1000.0) }
+    }
+
+    /// Apply desired state if `revision` is not stale. LiveTraceStore
+    /// increments a monotonic revision so a late `true` cannot outrun a
+    /// later `false` even if actor messages reorder.
+    public func setEnabled(_ enabled: Bool, revision: UInt64) {
+        guard revision >= appliedRevision else { return }
+        appliedRevision = revision
+        if enabled {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    /// Start the poll loop. Idempotent: a live task is left running.
+    public func start() {
+        guard task == nil else { return }
+        task = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    public func stop() {
+        task?.cancel()
+        task = nil
+        differ = CursorAggregateDiffer()
+        schedule = CursorLiveSchedule()
+        windowStartMs = nil
+        accountKey = nil
+        authSuspended = false
+        lastCursorPid = nil
+    }
+
+    func isRunning() -> Bool { task != nil }
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            let delay = await pollOnce()
+            let ns = UInt64(max(delay, 1) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: ns)
+        }
+    }
+
+    /// One poll. Returns the seconds to wait before the next attempt.
+    @discardableResult
+    func pollOnce() async -> TimeInterval {
+        let now = clock()
+        let proc = processSnapshot()
+        if authSuspended {
+            let relaunched = proc.running && proc.pid != nil && proc.pid != lastCursorPid
+            if relaunched {
+                authSuspended = false
+            } else {
+                if proc.running { lastCursorPid = proc.pid }
+                return CursorLiveSchedule.processCheckSecs
+            }
+        }
+        guard proc.running else {
+            lastCursorPid = nil
+            return schedule.delay(now: now, cursorRunning: false)
+        }
+        lastCursorPid = proc.pid
+
+        let nowMillis = nowMs()
+        if windowStartMs == nil {
+            windowStartMs = CursorAggregatedUsageFetcher.defaultStartMs(nowMs: nowMillis)
+        }
+        let start = windowStartMs!
+        let end = CursorAggregatedUsageFetcher.defaultEndMs(nowMs: nowMillis)
+
+        do {
+            let payload = try await fetch(start, end)
+            if Task.isCancelled { return CursorLiveSchedule.processCheckSecs }
+            if let key = payload.accountKey {
+                if let previous = accountKey, previous != key {
+                    differ = CursorAggregateDiffer()
+                }
+                accountKey = key
+            }
+            let events = differ.consume(payload: payload, nowMs: nowMillis)
+            if !events.isEmpty {
+                _ = await tailer.ingest(events)
+            }
+            schedule.noteSuccess(hadDelta: !events.isEmpty, now: now)
+            return schedule.delay(now: now, cursorRunning: true)
+        } catch let error as CursorLiveHTTPError {
+            if Task.isCancelled { return CursorLiveSchedule.processCheckSecs }
+            switch error {
+            case .status(401), .status(403):
+                authSuspended = true
+                lastCursorPid = proc.pid
+                return CursorLiveSchedule.processCheckSecs
+            case .status(429):
+                schedule.noteRateLimited()
+                return schedule.delay(now: now, cursorRunning: true)
+            case .status:
+                return CursorLiveSchedule.idleSecs
+            }
+        } catch {
+            if Task.isCancelled { return CursorLiveSchedule.processCheckSecs }
+            return CursorLiveSchedule.idleSecs
+        }
+    }
+}
+
+enum CursorProcess {
+    /// Cursor's production bundle id is a ToDesktop wrapper
+    /// (`com.todesktop.<id>`) that does not contain "cursor". Match the
+    /// exact localized name `Cursor` and the `Cursor.app` bundle path.
+    /// Do not substring-match bundle ids: `CursorUIViewService` is
+    /// `com.apple.TextInputUI.xpc.CursorUIViewService` and would keep
+    /// the gate open with no Cursor IDE or CLI present.
+    ///
+    /// Cursor CLI is not an `NSRunningApplication`. Also walk process
+    /// executable paths: the GUI main binary
+    /// (`.../Cursor.app/Contents/MacOS/Cursor`), official curl layout
+    /// (`~/.local/share/cursor-agent/versions/.../node`), Homebrew
+    /// `cursor-cli` (`.../Caskroom/cursor-cli/.../dist-package/node`),
+    /// and `cursor-agent` / `~/.local/bin/cursor`.
+    ///
+    /// A PATH `cursor` that resolves into `Cursor.app/.../app/bin/code`
+    /// is the IDE opener, not the agent CLI — do not treat that as CLI.
+    /// The running GUI app itself still gates polling via
+    /// `NSRunningApplication` and `looksLikeCursorGUI`.
+    /// A PATH `agent` symlink counts only after it resolves into a CLI
+    /// path. Skip Grok `agent`, helpers, `CursorUIViewService`, `tokcat`.
+    static func snapshot() -> CursorProcessSnapshot {
+        if let app = NSWorkspace.shared.runningApplications.first(where: isGUICursor) {
+            return CursorProcessSnapshot(running: true, pid: app.processIdentifier)
+        }
+        if let pid = matchingPid() {
+            return CursorProcessSnapshot(running: true, pid: pid)
+        }
+        return CursorProcessSnapshot(running: false, pid: nil)
+    }
+
+    static func isGUICursor(_ app: NSRunningApplication) -> Bool {
+        isGUICursor(
+            localizedName: app.localizedName,
+            bundleName: app.bundleURL?.lastPathComponent,
+            bundleId: app.bundleIdentifier)
+    }
+
+    /// Testable GUI predicate. Bundle-id substring matches are rejected
+    /// on purpose (`CursorUIViewService` contains "cursor").
+    static func isGUICursor(
+        localizedName: String?,
+        bundleName: String?,
+        bundleId _: String? = nil
+    ) -> Bool {
+        if localizedName == "Cursor" { return true }
+        if bundleName == "Cursor.app" { return true }
+        return false
+    }
+
+    /// Main GUI executable only. Helpers and the `code` shim do not count.
+    static func looksLikeCursorGUI(path: String) -> Bool {
+        let resolved = (path as NSString).resolvingSymlinksInPath
+        return isGUICursorExecutable(path) || isGUICursorExecutable(resolved)
+    }
+
+    static func looksLikeCursorCLI(path: String) -> Bool {
+        let resolved = (path as NSString).resolvingSymlinksInPath
+        if isInsideCursorApp(path) || isInsideCursorApp(resolved) {
+            return false
+        }
+        return matchesCursorCLIPath(path) || matchesCursorCLIPath(resolved)
+    }
+
+    static func looksLikeCursor(path: String) -> Bool {
+        looksLikeCursorGUI(path: path) || looksLikeCursorCLI(path: path)
+    }
+
+    static func isInsideCursorApp(_ path: String) -> Bool {
+        path.lowercased().contains("/cursor.app/")
+    }
+
+    private static func isGUICursorExecutable(_ path: String) -> Bool {
+        path.lowercased().hasSuffix("/cursor.app/contents/macos/cursor")
+    }
+
+    private static func matchesCursorCLIPath(_ path: String) -> Bool {
+        let lower = path.lowercased()
+        if isInsideCursorApp(lower) { return false }
+        // Official curl install: ~/.local/share/cursor-agent/versions/<ver>/node
+        if lower.contains("/cursor-agent/versions/") && lower.hasSuffix("/node") {
+            return true
+        }
+        if lower.hasSuffix("/cursor-agent") { return true }
+        // Homebrew cask `cursor-cli`: long-lived process is dist-package/node.
+        if lower.contains("/cursor-cli/") && lower.hasSuffix("/dist-package/node") {
+            return true
+        }
+        if lower.hasSuffix("/bin/cursor") { return true }
+        return false
+    }
+
+    private static func matchingPid() -> pid_t? {
+        let needed = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard needed > 0 else { return nil }
+        var pids = [pid_t](repeating: 0, count: Int(needed))
+        let filled = proc_listpids(
+            UInt32(PROC_ALL_PIDS), 0, &pids,
+            Int32(MemoryLayout<pid_t>.stride * pids.count))
+        guard filled > 0 else { return nil }
+        let count = Int(filled) / MemoryLayout<pid_t>.stride
+        var pathBuf = [CChar](repeating: 0, count: Int(4 * MAXPATHLEN))
+        var preferred: pid_t?
+        var fallback: pid_t?
+        for pid in pids.prefix(count) where pid > 0 {
+            let n = proc_pidpath(pid, &pathBuf, UInt32(pathBuf.count))
+            guard n > 0 else { continue }
+            let bytes = pathBuf.prefix(Int(n)).map { UInt8(bitPattern: $0) }
+            let path = String(decoding: bytes, as: UTF8.self)
+            guard looksLikeCursor(path: path) else { continue }
+            let lower = path.lowercased()
+            if isGUICursorExecutable(lower)
+                || lower.hasSuffix("/bin/cursor")
+                || lower.hasSuffix("/cursor-agent") {
+                preferred = pid
+                break
+            }
+            if fallback == nil { fallback = pid }
+        }
+        return preferred ?? fallback
+    }
+}

--- a/native/LocalPackage/Sources/Model/Stores/LiveTraceStore.swift
+++ b/native/LocalPackage/Sources/Model/Stores/LiveTraceStore.swift
@@ -36,14 +36,27 @@ public final class LiveTraceStore: ObservableObject {
     @Published public private(set) var detailedTrace: Bool = false
 
     private let tailer: UsageTailer
+    private let cursorLive: CursorLiveProvider
     private var tickTask: Task<Void, Never>?
     private var hiddenClients: Set<String> = []
     /// Kept so a Settings change can recompute the rates without waiting for
     /// the next tick. One snapshot, not a history.
     private var lastSnapshot: LiveSnapshot?
+    private var cursorLiveEnabled = false
+    /// True after `start()` and until `stop()`. Independent of the
+    /// opt-in so a store that has not started never polls.
+    private var storeStarted = false
+    private var cursorLiveRevision: UInt64 = 0
 
     public init(tailer: UsageTailer = UsageTailer()) {
         self.tailer = tailer
+        self.cursorLive = CursorLiveProvider(tailer: tailer)
+    }
+
+    /// Test seam: inject a provider so enable/disable races can be observed.
+    init(tailer: UsageTailer, cursorLive: CursorLiveProvider) {
+        self.tailer = tailer
+        self.cursorLive = cursorLive
     }
 
     public func setDetailedTrace(_ detailed: Bool) {
@@ -63,8 +76,21 @@ public final class LiveTraceStore: ObservableObject {
         if let lastSnapshot { publish(lastSnapshot) }
     }
 
+    /// Same opt-in as the historical Cursor event cache. Off: no Cursor
+    /// live polls. On: start the adaptive poller.
+    ///
+    /// Each call hops back to the main actor and re-reads the *latest*
+    /// flags before talking to the provider, so a stale `start()` cannot
+    /// outrun a later opt-out.
+    public func setCursorLiveEnabled(_ enabled: Bool) {
+        cursorLiveEnabled = enabled
+        syncCursorLive()
+    }
+
     /// Start the 5s tick loop (immediate first tick). Idempotent.
     public func start() {
+        storeStarted = true
+        syncCursorLive()
         guard tickTask == nil else { return }
         tickTask = Task { [weak self, tailer] in
             while !Task.isCancelled {
@@ -118,7 +144,20 @@ public final class LiveTraceStore: ObservableObject {
     }
 
     public func stop() {
+        storeStarted = false
         tickTask?.cancel()
         tickTask = nil
+        syncCursorLive()
+    }
+
+    private func syncCursorLive() {
+        cursorLiveRevision += 1
+        let revision = cursorLiveRevision
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard revision == self.cursorLiveRevision else { return }
+            let want = self.storeStarted && self.cursorLiveEnabled
+            await self.cursorLive.setEnabled(want, revision: revision)
+        }
     }
 }

--- a/native/LocalPackage/Sources/UserInterface/Views/SettingsSheet.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/SettingsSheet.swift
@@ -195,7 +195,7 @@ struct SettingsSheet: View {
         }
     }
 
-    // MARK: - Cursor usage (opt-in event fetch from cursor.com)
+    // MARK: - Cursor usage (opt-in event fetch + live poll from cursor.com)
 
     private var cursorUsageSection: some View {
         section(label: "Cursor usage") {
@@ -205,6 +205,11 @@ struct SettingsSheet: View {
                     get: { store.settings.cursorUsage },
                     set: { setCursorUsage($0) }),
                 disabled: cursorUsageBusy)
+            Text("Loads history and polls live usage with your Cursor session. Polling pauses when Cursor IDE and Cursor CLI are both quit.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 6)
             if let error = quotaStore.cursorUsageError {
                 Text(error)
                     .font(.system(size: 11))

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageTraceCard.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageTraceCard.swift
@@ -24,6 +24,7 @@ public struct UsageTraceCard: View {
     private static let registryIds: [String: String] = [
         "claude-code": "claude",
         "codex-cli": "codex",
+        "cursor": "cursor",
     ]
 
     private func style(for tailClientId: String) -> ClientStyle {

--- a/native/LocalPackage/Tests/CollectorTests/CursorAggregateTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/CursorAggregateTests.swift
@@ -1,0 +1,338 @@
+import Foundation
+import Testing
+
+@testable import Collector
+
+@Suite struct CursorAggregateParseTests {
+    @Test func parsesPerModelAggregations() throws {
+        let json = """
+        {
+          "aggregations": [
+            {
+              "modelIntent": "claude-opus-5-thinking-high",
+              "inputTokens": "62",
+              "outputTokens": 17769,
+              "cacheWriteTokens": 34428,
+              "cacheReadTokens": "4548472"
+            }
+          ],
+          "totalInputTokens": 62,
+          "totalOutputTokens": 17769,
+          "totalCacheWriteTokens": 34428,
+          "totalCacheReadTokens": 4548472
+        }
+        """
+        let snap = try parseCursorAggregateResponse(Data(json.utf8))
+        #expect(snap.models.count == 1)
+        let totals = snap.models["claude-opus-5-thinking-high"]
+        #expect(totals?.input == 62)
+        #expect(totals?.output == 17769)
+        #expect(totals?.cacheWrite == 34428)
+        #expect(totals?.cacheRead == 4_548_472)
+    }
+
+    @Test func fallsBackToTopLevelTotalsWhenAggregationsEmpty() throws {
+        let json = """
+        {
+          "aggregations": [],
+          "totalInputTokens": 10,
+          "totalOutputTokens": 20,
+          "totalCacheWriteTokens": 3,
+          "totalCacheReadTokens": 4
+        }
+        """
+        let snap = try parseCursorAggregateResponse(Data(json.utf8))
+        #expect(snap.models["cursor"]?.input == 10)
+        #expect(snap.models["cursor"]?.output == 20)
+        #expect(snap.models["cursor"]?.cacheWrite == 3)
+        #expect(snap.models["cursor"]?.cacheRead == 4)
+    }
+
+    @Test func mergesDuplicateModelIntent() throws {
+        let json = """
+        {
+          "aggregations": [
+            {"modelIntent": "composer", "inputTokens": 1, "outputTokens": 2,
+             "cacheWriteTokens": 0, "cacheReadTokens": 0},
+            {"modelIntent": "composer", "inputTokens": 3, "outputTokens": 4,
+             "cacheWriteTokens": 1, "cacheReadTokens": 5}
+          ]
+        }
+        """
+        let snap = try parseCursorAggregateResponse(Data(json.utf8))
+        #expect(snap.models["composer"]?.input == 4)
+        #expect(snap.models["composer"]?.output == 6)
+        #expect(snap.models["composer"]?.cacheWrite == 1)
+        #expect(snap.models["composer"]?.cacheRead == 5)
+    }
+
+    @Test func rejectsInvalidJSON() {
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data("not-json".utf8))
+        }
+    }
+
+    @Test func rejectsSchemaLessObject() {
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data("{}".utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"percentOfBurstUsed":1}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":null}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{}]}"#.utf8))
+        }
+    }
+
+    @Test func rejectsOutOfRangeTokenField() {
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":1e300}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":"1e19"}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":{"x":1}}]}"#.utf8))
+        }
+        // Exact Int64.max must not reach trapping `+` in merge or diff.
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":9223372036854775807}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":9223372036854775807},{"modelIntent":"m","inputTokens":1}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":9223372036854775807,"outputTokens":1}]}"#.utf8))
+        }
+        // Shared parser bit-pattern-wraps u64-range ints; do not coerce to 0.
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":18446744073709551615}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":-1}]}"#.utf8))
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":1000000000000001}]}"#.utf8))
+        }
+    }
+
+    @Test func acceptsTokenFieldAtDomainCeiling() throws {
+        let payload = try parseCursorAggregateResponse(
+            Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":1000000000000000}]}"#.utf8))
+        #expect(payload.models["m"]?.input == cursorTokenFieldMax)
+    }
+
+    @Test func duplicateMergeOverflowThrows() {
+        let a = CursorModelPartial(input: Int64.max)
+        let b = CursorModelPartial(input: 1)
+        #expect(throws: QuotaError.self) {
+            _ = try a.merging(b)
+        }
+        #expect(throws: QuotaError.self) {
+            try parseCursorAggregateResponse(Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":1000000000000000},{"modelIntent":"m","inputTokens":1000000000000000}]}"#.utf8))
+        }
+    }
+
+    @Test func omittedCountersStayNil() throws {
+        let payload = try parseCursorAggregateResponse(
+            Data(#"{"aggregations":[{"modelIntent":"m","inputTokens":100}]}"#.utf8))
+        #expect(payload.models["m"]?.input == 100)
+        #expect(payload.models["m"]?.output == nil)
+        #expect(payload.models["m"]?.cacheRead == nil)
+    }
+}
+
+@Suite struct CursorAggregateDifferTests {
+    @Test func firstConsumeIsSilentBaseline() {
+        var differ = CursorAggregateDiffer()
+        let snap = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 10, output: 20, cacheWrite: 1, cacheRead: 2)
+        ])
+        let events = differ.consume(snap, nowMs: 1_000)
+        #expect(events.isEmpty)
+        #expect(differ.didRebaseline)
+        #expect(differ.baseline == snap)
+    }
+
+    @Test func positiveDeltaEmitsPerModelEvent() {
+        var differ = CursorAggregateDiffer(baseline: CursorAggregateSnapshot(models: [
+            "Claude-Opus-5-20260101": CursorModelTotals(
+                input: 10, output: 20, cacheWrite: 1, cacheRead: 100)
+        ]))
+        let events = differ.consume(
+            CursorAggregateSnapshot(models: [
+                "Claude-Opus-5-20260101": CursorModelTotals(
+                    input: 12, output: 25, cacheWrite: 3, cacheRead: 140)
+            ]),
+            nowMs: 5_000)
+        #expect(events.count == 1)
+        #expect(events[0].client == "cursor")
+        #expect(events[0].agent == "main")
+        #expect(events[0].model == "claude-opus-5")
+        #expect(events[0].input == 2)
+        #expect(events[0].output == 5)
+        #expect(events[0].cacheWrite == 2)
+        #expect(events[0].cacheRead == 40)
+        #expect(events[0].tsMs == 5_000)
+        #expect(!differ.didRebaseline)
+    }
+
+    @Test func newModelIsDeltaFromZero() {
+        var differ = CursorAggregateDiffer(baseline: CursorAggregateSnapshot(models: [
+            "a": CursorModelTotals(input: 1, output: 1, cacheWrite: 0, cacheRead: 0)
+        ]))
+        let events = differ.consume(
+            CursorAggregateSnapshot(models: [
+                "a": CursorModelTotals(input: 1, output: 1, cacheWrite: 0, cacheRead: 0),
+                "b": CursorModelTotals(input: 4, output: 6, cacheWrite: 0, cacheRead: 0)
+            ]),
+            nowMs: 9)
+        #expect(events.count == 1)
+        #expect(events[0].model == "b")
+        #expect(events[0].input == 4)
+        #expect(events[0].output == 6)
+    }
+
+    @Test func oneDecreaseIsHeldSecondConfirmsRebaseline() {
+        let previous = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 100, output: 200, cacheWrite: 0, cacheRead: 0)
+        ])
+        var differ = CursorAggregateDiffer(baseline: previous)
+        let low = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 10, output: 20, cacheWrite: 0, cacheRead: 0)
+        ])
+        #expect(differ.consume(low, nowMs: 1).isEmpty)
+        #expect(!differ.didRebaseline)
+        #expect(differ.baseline == previous)
+
+        #expect(differ.consume(low, nowMs: 2).isEmpty)
+        #expect(differ.didRebaseline)
+        #expect(differ.baseline == low)
+    }
+
+    @Test func flickerDecreaseThenRecoveryEmitsOnlyRealDelta() {
+        let previous = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 100, output: 0, cacheWrite: 0, cacheRead: 0)
+        ])
+        var differ = CursorAggregateDiffer(baseline: previous)
+        let empty = CursorAggregateSnapshot()
+        #expect(differ.consume(empty, nowMs: 1).isEmpty)
+        #expect(differ.baseline == previous)
+
+        let recovered = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 101, output: 0, cacheWrite: 0, cacheRead: 0)
+        ])
+        let events = differ.consume(recovered, nowMs: 2)
+        #expect(events.count == 1)
+        #expect(events[0].input == 1)
+        #expect(!differ.didRebaseline)
+    }
+
+    @Test func omittedOutputDoesNotFakeADecrease() {
+        var differ = CursorAggregateDiffer(baseline: CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 100, output: 100, cacheWrite: 0, cacheRead: 0)
+        ]))
+        let partial = CursorAggregatePayload(models: [
+            "m": CursorModelPartial(input: 100)
+        ])
+        #expect(differ.consume(payload: partial, nowMs: 1).isEmpty)
+        #expect(!differ.didRebaseline)
+        #expect(differ.baseline?.models["m"]?.output == 100)
+
+        let recovered = CursorAggregatePayload(models: [
+            "m": CursorModelPartial(input: 100, output: 101)
+        ])
+        let events = differ.consume(payload: recovered, nowMs: 2)
+        #expect(events.count == 1)
+        #expect(events[0].output == 1)
+        #expect(events[0].input == 0)
+    }
+
+    @Test func overflowDeltaDoesNotTrapOrEmit() {
+        var differ = CursorAggregateDiffer(baseline: CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals()
+        ]))
+        let events = differ.consume(
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: Int64.max, output: 1)
+            ]),
+            nowMs: 1)
+        #expect(events.isEmpty)
+        #expect(!differ.didRebaseline)
+    }
+
+    @Test func domainCeilingDeltaEmits() {
+        var differ = CursorAggregateDiffer(baseline: CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals()
+        ]))
+        let events = differ.consume(
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: cursorTokenFieldMax)
+            ]),
+            nowMs: 1)
+        #expect(events.count == 1)
+        #expect(events[0].input == cursorTokenFieldMax)
+    }
+
+    @Test func unchangedSnapshotEmitsNothing() {
+        let snap = CursorAggregateSnapshot(models: [
+            "m": CursorModelTotals(input: 1, output: 2, cacheWrite: 3, cacheRead: 4)
+        ])
+        var differ = CursorAggregateDiffer(baseline: snap)
+        #expect(differ.consume(snap, nowMs: 1).isEmpty)
+        #expect(!differ.didRebaseline)
+    }
+}
+
+@Suite struct CursorLiveScheduleTests {
+    @Test func activeThenIdleThenLongIdle() {
+        var schedule = CursorLiveSchedule()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        schedule.noteSuccess(hadDelta: false, now: t0)
+        #expect(schedule.delay(now: t0, cursorRunning: true)
+                == CursorLiveSchedule.activeSecs)
+
+        let tIdle = t0.addingTimeInterval(CursorLiveSchedule.idleAfterSecs + 1)
+        #expect(schedule.delay(now: tIdle, cursorRunning: true)
+                == CursorLiveSchedule.idleSecs)
+
+        let tLong = t0.addingTimeInterval(CursorLiveSchedule.longIdleAfterSecs + 1)
+        #expect(schedule.delay(now: tLong, cursorRunning: true)
+                == CursorLiveSchedule.idleLongSecs)
+    }
+
+    @Test func recentDeltaKeepsActiveCadence() {
+        var schedule = CursorLiveSchedule()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        schedule.noteSuccess(hadDelta: false, now: t0)
+        let later = t0.addingTimeInterval(CursorLiveSchedule.longIdleAfterSecs)
+        schedule.noteSuccess(hadDelta: true, now: later)
+        #expect(schedule.delay(now: later, cursorRunning: true)
+                == CursorLiveSchedule.activeSecs)
+    }
+
+    @Test func processDownUsesProcessCheckInterval() {
+        var schedule = CursorLiveSchedule()
+        schedule.noteSuccess(hadDelta: true, now: Date(timeIntervalSince1970: 1))
+        #expect(schedule.delay(
+            now: Date(timeIntervalSince1970: 2), cursorRunning: false)
+                == CursorLiveSchedule.processCheckSecs)
+    }
+
+    @Test func rateLimitEscalatesThenResetsOnSuccess() {
+        var schedule = CursorLiveSchedule()
+        let now = Date(timeIntervalSince1970: 1)
+        schedule.noteRateLimited()
+        #expect(schedule.delay(now: now, cursorRunning: true)
+                == CursorLiveSchedule.rateLimitSecs)
+        schedule.noteRateLimited()
+        #expect(schedule.delay(now: now, cursorRunning: true)
+                == CursorLiveSchedule.rateLimitLongSecs)
+        schedule.noteSuccess(hadDelta: false, now: now)
+        #expect(schedule.delay(now: now, cursorRunning: true)
+                == CursorLiveSchedule.activeSecs)
+    }
+}

--- a/native/LocalPackage/Tests/CollectorTests/CursorIngestTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/CursorIngestTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import Collector
+
+@Suite struct CursorIngestTests {
+    @Test func ingestAddsEventsAndTraceSeesCursor() async {
+        let now: Int64 = 1_700_000_000_000
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { now }))
+        let added = await tailer.ingest([
+            UsageEvent(
+                tsMs: now - 1_000, client: tailClientCursor, agent: "main",
+                model: "claude-opus-5", input: 10, output: 20,
+                cacheRead: 5, cacheWrite: 1)
+        ])
+        #expect(added == 1)
+        let buckets = await tailer.trace(windowSecs: 600)
+        #expect(buckets.count == 1)
+        #expect(buckets[0].client == "cursor")
+        #expect(buckets[0].model == "claude-opus-5")
+        #expect(buckets[0].tokens == 36)
+        #expect(buckets[0].messages == 1)
+        #expect(await tailer.ratePerMin() == Double(Float(36)))
+    }
+
+    @Test func ingestSkipsEmptyAndTrimsExpired() async {
+        let now: Int64 = 2_000_000_000_000
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { now }))
+        let added = await tailer.ingest([
+            UsageEvent(
+                tsMs: now, client: tailClientCursor, agent: "main",
+                model: "a", input: 0, output: 0, cacheRead: 0, cacheWrite: 0),
+            UsageEvent(
+                tsMs: now - (eventWindowSecs + 10) * 1000,
+                client: tailClientCursor, agent: "main",
+                model: "old", input: 9, output: 0, cacheRead: 0, cacheWrite: 0),
+            UsageEvent(
+                tsMs: now - 1_000, client: tailClientCursor, agent: "main",
+                model: "fresh", input: 3, output: 0, cacheRead: 0, cacheWrite: 0)
+        ])
+        #expect(added == 1)
+        let snap = await tailer.eventsSnapshot()
+        #expect(snap.count == 1)
+        #expect(snap[0].model == "fresh")
+    }
+
+    @Test func manyCeilingEventsDoNotTrapWindowTotal() async {
+        let now: Int64 = 3_000_000_000_000
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { now }))
+        // 2400 events × 4×10^15 exceeds Int64.max. Trapping `+` used to
+        // SIGTRAP inside windowTotal / trace; satAdd must saturate.
+        let incoming = (0..<2400).map { i in
+            UsageEvent(
+                tsMs: now - 1_000, client: tailClientCursor, agent: "main",
+                model: "m\(i)", input: cursorTokenFieldMax,
+                output: cursorTokenFieldMax, cacheRead: cursorTokenFieldMax,
+                cacheWrite: cursorTokenFieldMax)
+        }
+        #expect(await tailer.ingest(incoming) == 2400)
+        #expect(await tailer.ratePerMin() == Double(Float(Int64.max)))
+        let buckets = await tailer.trace(windowSecs: 60)
+        #expect(!buckets.isEmpty)
+        let traced = buckets.reduce(Int64(0)) { satAdd($0, $1.tokens) }
+        #expect(traced == Int64.max)
+    }
+}

--- a/native/LocalPackage/Tests/ModelTests/CursorLiveProviderTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/CursorLiveProviderTests.swift
@@ -1,0 +1,354 @@
+import Collector
+import Foundation
+import Testing
+
+@testable import Model
+
+@Suite struct CursorLiveProviderTests {
+    @Test func firstPollIsBaselineSecondPollIngestsDelta() async {
+        let now: Int64 = 1_800_000_000_000
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { now }))
+        let snaps = [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 10, output: 0, cacheWrite: 0, cacheRead: 0)
+            ]),
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 15, output: 4, cacheWrite: 0, cacheRead: 0)
+            ]),
+        ]
+        let box = FetchBox(snaps: snaps)
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: Double(now) / 1000.0) },
+            nowMs: { now })
+
+        let d1 = await provider.pollOnce()
+        #expect(d1 == CursorLiveSchedule.activeSecs)
+        #expect(await tailer.eventsSnapshot().isEmpty)
+
+        let d2 = await provider.pollOnce()
+        #expect(d2 == CursorLiveSchedule.activeSecs)
+        let events = await tailer.eventsSnapshot()
+        #expect(events.count == 1)
+        #expect(events[0].input == 5)
+        #expect(events[0].output == 4)
+        #expect(events[0].client == "cursor")
+        #expect(box.calls == 2)
+    }
+
+    @Test func skippedWhenCursorNotRunning() async {
+        let tailer = UsageTailer()
+        let box = FetchBox(snaps: [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 1, output: 0, cacheWrite: 0, cacheRead: 0)
+            ])
+        ])
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { .init(running: false) },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+
+        let delay = await provider.pollOnce()
+        #expect(delay == CursorLiveSchedule.processCheckSecs)
+        #expect(box.calls == 0)
+        #expect(await tailer.eventsSnapshot().isEmpty)
+    }
+
+    @Test func rateLimit429BacksOff() async {
+        let tailer = UsageTailer()
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in throw CursorLiveHTTPError.status(429) },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+
+        #expect(await provider.pollOnce() == CursorLiveSchedule.rateLimitSecs)
+        #expect(await provider.pollOnce() == CursorLiveSchedule.rateLimitLongSecs)
+        #expect(await tailer.eventsSnapshot().isEmpty)
+    }
+
+    @Test func unauthorizedSuspendsUntilPidChanges() async {
+        let tailer = UsageTailer()
+        let box = FetchBox(snaps: [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 1, output: 0, cacheWrite: 0, cacheRead: 0)
+            ])
+        ])
+        box.throwStatus = 401
+        let proc = ProcessBox(running: true, pid: 11)
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { proc.snapshot },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+
+        #expect(await provider.pollOnce() == CursorLiveSchedule.processCheckSecs)
+        #expect(box.calls == 1)
+        #expect(await provider.pollOnce() == CursorLiveSchedule.processCheckSecs)
+        #expect(box.calls == 1)
+
+        // Fast relaunch: never sampled as not-running.
+        proc.pid = 12
+        box.throwStatus = nil
+        _ = await provider.pollOnce()
+        #expect(box.calls == 2)
+    }
+
+    @Test func mixedErrorDoesNotSkipFirst429Step() async {
+        let tailer = UsageTailer()
+        let box = FetchBox(snaps: [])
+        box.throwStatus = 500
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+
+        #expect(await provider.pollOnce() == CursorLiveSchedule.idleSecs)
+        box.throwStatus = 429
+        #expect(await provider.pollOnce() == CursorLiveSchedule.rateLimitSecs)
+    }
+
+    @Test func pinsStartDateAcrossPolls() async {
+        let clock = ClockBox(nowMs: 1_800_000_000_000)
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { clock.nowMs }))
+        let box = FetchBox(snaps: [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 1, output: 0, cacheWrite: 0, cacheRead: 0)
+            ]),
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 2, output: 0, cacheWrite: 0, cacheRead: 0)
+            ]),
+        ])
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { start, end in try box.next(start: start, end: end) },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: Double(clock.nowMs) / 1000.0) },
+            nowMs: { clock.nowMs })
+
+        _ = await provider.pollOnce()
+        clock.nowMs += 60_000
+        _ = await provider.pollOnce()
+        #expect(box.starts.count == 2)
+        #expect(box.starts[0] == box.starts[1])
+        #expect(box.ends[1] > box.ends[0])
+    }
+
+    @Test func staleEnableRevisionIsIgnored() async {
+        let tailer = UsageTailer()
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in throw CursorLiveHTTPError.status(500) },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+
+        await provider.setEnabled(true, revision: 1)
+        await provider.setEnabled(false, revision: 2)
+        await provider.setEnabled(true, revision: 1)
+        #expect(await provider.isRunning() == false)
+    }
+
+    @Test func storeEnableDisableConvergesOff() async {
+        let tailer = UsageTailer()
+        let box = FetchBox(snaps: [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 1, output: 0, cacheWrite: 0, cacheRead: 0)
+            ])
+        ])
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: 1) },
+            nowMs: { 1_000 })
+        let store = await MainActor.run {
+            LiveTraceStore(tailer: tailer, cursorLive: provider)
+        }
+        await MainActor.run {
+            store.start()
+            store.setCursorLiveEnabled(true)
+            store.setCursorLiveEnabled(false)
+        }
+        for _ in 0..<50 {
+            await Task.yield()
+            if await provider.isRunning() == false { break }
+        }
+        #expect(await provider.isRunning() == false)
+        #expect(box.calls == 0)
+    }
+
+    @Test func accountKeyChangeRebaselinesSilently() async {
+        let now: Int64 = 1_800_000_000_000
+        let tailer = UsageTailer(config: UsageTailerConfig(nowMs: { now }))
+        let box = FetchBox(snaps: [
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 10, output: 0, cacheWrite: 0, cacheRead: 0)
+            ], accountKey: "user-a"),
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 10_000, output: 0, cacheWrite: 0, cacheRead: 0)
+            ], accountKey: "user-b"),
+            CursorAggregateSnapshot(models: [
+                "m": CursorModelTotals(input: 10_001, output: 0, cacheWrite: 0, cacheRead: 0)
+            ], accountKey: "user-b"),
+        ])
+        let provider = CursorLiveProvider(
+            tailer: tailer,
+            fetch: { _, _ in try box.next() },
+            processSnapshot: { .init(running: true, pid: 1) },
+            clock: { Date(timeIntervalSince1970: Double(now) / 1000.0) },
+            nowMs: { now })
+
+        _ = await provider.pollOnce()
+        _ = await provider.pollOnce()
+        #expect(await tailer.eventsSnapshot().isEmpty)
+        _ = await provider.pollOnce()
+        let events = await tailer.eventsSnapshot()
+        #expect(events.count == 1)
+        #expect(events[0].input == 1)
+    }
+
+    @Test func looksLikeCursorCLIAcceptsAgentAndBinCursor() {
+        #expect(CursorProcess.looksLikeCursorCLI(
+            path: "/Users/me/.local/bin/cursor"))
+        #expect(CursorProcess.looksLikeCursorCLI(
+            path: "/Users/me/.local/bin/cursor-agent"))
+        #expect(CursorProcess.looksLikeCursorCLI(
+            path: "/Users/me/.local/share/cursor-agent/versions/2026.08.25-3e8eec8/node"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/System/Library/PrivateFrameworks/TextInputUIMacHelper.framework/Versions/A/XPCServices/CursorUIViewService.xpc/Contents/MacOS/CursorUIViewService"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/Applications/Cursor.app/Contents/MacOS/Cursor"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/Users/me/git-repos/tokcat-worktrees/tokcat-cursor-live-session/native/build-local/Build/Products/Debug/Tokcat.app/Contents/MacOS/tokcat"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/Users/me/.grok/bin/agent"))
+        #expect(CursorProcess.looksLikeCursorCLI(
+            path: "/opt/homebrew/Caskroom/cursor-cli/2026.08.25-3e8eec8/dist-package/node"))
+        #expect(CursorProcess.looksLikeCursorCLI(
+            path: "/usr/local/Caskroom/cursor-cli/2026.01.23-916f423/dist-package/cursor-agent"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/Applications/Cursor.app/Contents/Resources/app/bin/code"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/opt/homebrew/Caskroom/some-other-cli/1.0/dist-package/node"))
+        #expect(CursorProcess.looksLikeCursorGUI(
+            path: "/Applications/Cursor.app/Contents/MacOS/Cursor"))
+        #expect(CursorProcess.looksLikeCursor(
+            path: "/Applications/Cursor.app/Contents/MacOS/Cursor"))
+        #expect(!CursorProcess.looksLikeCursorGUI(
+            path: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper.app/Contents/MacOS/Cursor Helper"))
+        #expect(!CursorProcess.looksLikeCursorGUI(
+            path: "/Applications/Cursor.app/Contents/Resources/app/bin/code"))
+        #expect(!CursorProcess.looksLikeCursor(
+            path: "/Applications/Cursor.app/Contents/Resources/app/bin/code"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/tmp/cursor-cli/unrelated-daemon"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/tmp/cursor-agent/unrelated-daemon"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/tmp/cursor-cli/readme-preview"))
+        #expect(!CursorProcess.looksLikeCursorCLI(
+            path: "/opt/homebrew/Caskroom/cursor-cli/2026.08.25-3e8eec8/unrelated"))
+    }
+
+    @Test func isGUICursorRejectsCursorUIViewService() {
+        #expect(CursorProcess.isGUICursor(
+            localizedName: "Cursor", bundleName: "Cursor.app",
+            bundleId: "com.todesktop.230313mzl4w4u92"))
+        #expect(CursorProcess.isGUICursor(
+            localizedName: "Cursor", bundleName: nil, bundleId: nil))
+        #expect(CursorProcess.isGUICursor(
+            localizedName: nil, bundleName: "Cursor.app", bundleId: nil))
+        #expect(!CursorProcess.isGUICursor(
+            localizedName: "CursorUIViewService",
+            bundleName: "CursorUIViewService.xpc",
+            bundleId: "com.apple.TextInputUI.xpc.CursorUIViewService"))
+        #expect(!CursorProcess.isGUICursor(
+            localizedName: "Cursor Helper",
+            bundleName: "Cursor Helper.app",
+            bundleId: "com.github.Electron.helper"))
+        #expect(!CursorProcess.isGUICursor(
+            localizedName: nil, bundleName: nil,
+            bundleId: "com.apple.TextInputUI.xpc.CursorUIViewService"))
+    }
+
+    @Test func looksLikeCursorCLIResolvesAgentSymlink() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tokcat-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let target = dir.appendingPathComponent("cursor-agent")
+        try Data("x".utf8).write(to: target)
+        let agent = dir.appendingPathComponent("agent")
+        try FileManager.default.createSymbolicLink(
+            atPath: agent.path, withDestinationPath: target.path)
+        #expect(CursorProcess.looksLikeCursorCLI(path: agent.path))
+
+        let grok = dir.appendingPathComponent("grok")
+        try Data("g".utf8).write(to: grok)
+        let grokAgent = dir.appendingPathComponent("bin-agent")
+        try FileManager.default.createSymbolicLink(
+            atPath: grokAgent.path, withDestinationPath: grok.path)
+        #expect(!CursorProcess.looksLikeCursorCLI(path: grokAgent.path))
+
+        let appBin = dir.appendingPathComponent("Cursor.app/Contents/Resources/app/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: appBin, withIntermediateDirectories: true)
+        let code = appBin.appendingPathComponent("code")
+        try Data("c".utf8).write(to: code)
+        let brewCursor = dir.appendingPathComponent("bin/cursor")
+        try FileManager.default.createDirectory(
+            at: brewCursor.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: brewCursor.path, withDestinationPath: code.path)
+        #expect(!CursorProcess.looksLikeCursorCLI(path: brewCursor.path))
+    }
+}
+
+private final class FetchBox: @unchecked Sendable {
+    private let snaps: [CursorAggregateSnapshot]
+    private(set) var calls = 0
+    private(set) var starts: [Int64] = []
+    private(set) var ends: [Int64] = []
+    private var index = 0
+    var throwStatus: Int?
+
+    init(snaps: [CursorAggregateSnapshot]) { self.snaps = snaps }
+
+    func next(start: Int64 = 0, end: Int64 = 0) throws -> CursorAggregatePayload {
+        calls += 1
+        starts.append(start)
+        ends.append(end)
+        if let throwStatus {
+            throw CursorLiveHTTPError.status(throwStatus)
+        }
+        guard index < snaps.count else {
+            throw CursorLiveHTTPError.status(500)
+        }
+        defer { index += 1 }
+        return snaps[index].asPayload
+    }
+}
+
+private final class ProcessBox: @unchecked Sendable {
+    var running: Bool
+    var pid: Int32?
+    init(running: Bool, pid: Int32?) {
+        self.running = running
+        self.pid = pid
+    }
+    var snapshot: CursorProcessSnapshot { .init(running: running, pid: pid) }
+}
+
+private final class ClockBox: @unchecked Sendable {
+    var nowMs: Int64
+    init(nowMs: Int64) { self.nowMs = nowMs }
+}

--- a/native/LocalPackage/Tests/ModelTests/TailTraceCollapseTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/TailTraceCollapseTests.swift
@@ -58,4 +58,15 @@ private func row(_ client: String, _ agent: String, _ model: String,
     @Test func emptyInputYieldsEmptyOutput() {
         #expect(TraceCollapse.collapseByClient([]).isEmpty)
     }
+
+    @Test func compactCollapseSaturatesManyCeilingRows() {
+        let perRow: Int64 = 4_000_000_000_000_000
+        let rows = (0..<2400).map { i in
+            row("cursor", "main", "m\(i)", tokens: perRow, rate: 1)
+        }
+        let collapsed = TraceCollapse.collapseByClient(rows)
+        #expect(collapsed.count == 1)
+        #expect(collapsed[0].client == "cursor")
+        #expect(collapsed[0].tokens == Int64.max)
+    }
 }

--- a/native/Tokcat/TokcatApp.swift
+++ b/native/Tokcat/TokcatApp.swift
@@ -155,6 +155,13 @@ final class AppMain {
                     .removeDuplicates()
                     .sink { detailed in liveTrace.setDetailedTrace(detailed) }
                     .store(in: &Self.cancellables)
+                // Same Cursor opt-in as the historical event cache: live
+                // polling is another cursor.com/api2.cursor.sh call.
+                store.$settings
+                    .map(\.cursorUsage)
+                    .removeDuplicates()
+                    .sink { enabled in liveTrace.setCursorLiveEnabled(enabled) }
+                    .store(in: &Self.cancellables)
 
                 store.start()
                 liveTrace.start()


### PR DESCRIPTION
Cursor has no local billed-token ledger, so the Live session card could not show it. The existing Settings → Cursor usage opt-in already backfills history from cursor.com; this extends that same consent to a live poll.

## Approach

- Poll `DashboardService/GetAggregatedUsageEvents` with a pinned `startDate` (first poll: now − 6h) and diff per-`modelIntent` totals. First consume is a silent baseline, same pattern as Hermes.
- `UsageTailer.ingest` takes the positive deltas. The tailer stays a file-offset actor; the network source lives in Model (`CursorLiveProvider`).
- Same `cursorUsage` toggle as history. Quota fetch stays independent. Polling pauses when Cursor IDE and Cursor CLI are both quit (15s active / 60–120s idle / 30s process check; 429 backs off to 120s then 300s).
- Numeric domain: omit-zero stays nil, reject negatives / u64 wraps / values above `10^15`, saturate window/trace/compact-collapse sums with `satAdd`.
- Process gate matches Cursor.app (exact name or `Cursor.app`) and documented CLI layouts (`cursor-agent/versions/.../node`, Homebrew `cursor-cli/.../dist-package/node`). It does not match `CursorUIViewService`, helpers, Grok `agent`, or the IDE `code` shim.

## Testing

`swift test` in `native/LocalPackage`: **253 tests / 43 suites** after rebase onto `main@30efb76`.

## Not in this PR

- No `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` bump — that belongs in a release commit.
- No second live-vs-history toggle, live 401 UI, `Retry-After`, or `ai_code_hashes` trigger.