### PR TITLE
harness: force review-prompt fetch refspecs

### DIFF
--- a/.claude/harness/REVIEW_PROMPT.md
+++ b/.claude/harness/REVIEW_PROMPT.md
@@ -25,12 +25,12 @@ Therefore:
 
 ```sh
 # Pin main to a named ref — a later fetch would overwrite FETCH_HEAD.
-git fetch origin main:refs/remotes/origin/main
+git fetch origin +main:refs/remotes/origin/main
 git show refs/remotes/origin/main:.claude/harness/REVIEW_PROMPT.md   # canonical instructions
 git show refs/remotes/origin/main:AGENTS.md                          # canonical invariants
 git diff refs/remotes/origin/main...HEAD                             # the diff you are reviewing
 # fork PR whose head is not checked out:
-git fetch origin "pull/<N>/head:refs/heads/pr-<N>"
+git fetch origin "+pull/<N>/head:refs/heads/pr-<N>"
 git diff refs/remotes/origin/main...pr-<N>
 ```
 


### PR DESCRIPTION
One-liner from the auto-review note on #78: non-forced refspecs can keep a stale `pr-<N>` ref after a force-push, producing a silently wrong diff. Both fetches now use `+`.