### PR TITLE
Release Tokcat 0.3.1

### DIFF
--- a/native/LocalPackage/Tests/CollectorTests/TailUsageTailerTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/TailUsageTailerTests.swift
@@ -18,10 +18,14 @@ private func tailTempDir(_ name: String) throws -> URL {
     return dir
 }
 
+// pid + millisecond is not unique: swift-testing runs the tests in a suite
+// in parallel, so two calls with the same `name` can land on one path and
+// one test's cleanup `defer` deletes the file the other is still reading.
 private func tailTempFile(_ name: String) -> String {
     FileManager.default.temporaryDirectory
         .appendingPathComponent(
-            "tokcat-usage-tail-\(name)-\(ProcessInfo.processInfo.processIdentifier)-\(nowMs()).jsonl"
+            "tokcat-usage-tail-\(name)-\(ProcessInfo.processInfo.processIdentifier)"
+                + "-\(nowMs())-\(UInt32.random(in: 0..<UInt32.max)).jsonl"
         ).path
 }
 

--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.3.0
-        CURRENT_PROJECT_VERSION: 10
+        MARKETING_VERSION: 0.3.1
+        CURRENT_PROJECT_VERSION: 11
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump only: `MARKETING_VERSION` 0.3.0 → 0.3.1, `CURRENT_PROJECT_VERSION` 10 → 11.

Ships #74 (Cursor live usage in the Live session card) plus the agent-visibility and menubar fixes merged since v0.3.0.