### PR TITLE
Release Tokcat 0.3.2

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.3.1
-        CURRENT_PROJECT_VERSION: 11
+        MARKETING_VERSION: 0.3.2
+        CURRENT_PROJECT_VERSION: 12
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Version bump only: `MARKETING_VERSION` 0.3.1 → 0.3.2, `CURRENT_PROJECT_VERSION` 11 → 12 (the published appcast is at 11, so Sparkle clients will see this one).

Ships #84 (Aside browser usage tracking — twelfth client, graph parser plus live tailer), the only change merged since v0.3.1.