### PR TITLE
Spin the refresh icon about the glyph's arc center

### DIFF
--- a/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift
@@ -26,6 +26,21 @@ struct HeaderBar: View {
 
     @State private var spinStartedAt: Date?
 
+    /// Where `arrow.clockwise`'s arc center sits inside its layout box.
+    /// The arrowhead overshoots the ring at the top, so the ink box is
+    /// taller above the arc than below it and the default `.center` anchor
+    /// lands 0.86 pt above the circle the eye tracks (12 pt semibold) — the
+    /// glyph then orbits a 1.7 pt circle once per turn instead of spinning
+    /// in place. Measured by rendering this view with `ImageRenderer` and
+    /// least-squares fitting a circle to the ring pixels, arrowhead trimmed
+    /// as outliers: the center is horizontally centered (|dx| < 0.05 pt) and
+    /// vertically at 0.5535 / 0.5578 / 0.5591 / 0.5577 of the box height at
+    /// 11 / 12 / 18 / 24 pt — scale invariant, so one unit-space constant
+    /// serves. 0.558 is the value for the 12 pt we draw (residual < 0.01 pt);
+    /// re-measure if this ever gets reused at a very different size, and
+    /// expect only an SF Symbols redesign of the glyph to move it.
+    private static let refreshArcCenter = UnitPoint(x: 0.5, y: 0.558)
+
     /// The button drives both stores, so it has to keep spinning until the
     /// slower one lands — quota is the slower one (upstream calls plus
     /// subprocess spawns) and is usually why the user pressed Refresh.
@@ -79,9 +94,11 @@ struct HeaderBar: View {
                     TimelineView(.animation) { context in
                         Image(systemName: "arrow.clockwise")
                             .font(.system(size: 12, weight: .semibold))
-                            .rotationEffect(.degrees(
-                                context.date.timeIntervalSince(startedAt)
-                                    / 0.8 * 360))
+                            .rotationEffect(
+                                .degrees(
+                                    context.date.timeIntervalSince(startedAt)
+                                        / 0.8 * 360),
+                                anchor: Self.refreshArcCenter)
                     }
                 } else {
                     Image(systemName: "arrow.clockwise")


### PR DESCRIPTION
🤖 **Claude Code**

## Summary

`.rotationEffect(_)` pivots about `anchor: .center` — the center of the **layout box**. `arrow.clockwise`'s arrowhead overshoots the ring at the top, so the ink box is taller above the arc than below it, and the default pivot lands 0.86 pt above the circle the eye tracks at our 12 pt. The glyph orbited a 1.72 pt circle (14 % of its width) once per revolution instead of spinning in place, most visible during a slow quota refresh.

The fix is one `anchor:` argument pinning the pivot to the measured arc center, `UnitPoint(x: 0.5, y: 0.558)`. Nothing else changes: the time-driven `TimelineView` spin stays exactly as it is (the state-animated `repeatForever` that stuttered on spin-up and unwound backward is not reintroduced), and at rest the rotation is the identity transform at any anchor, so the icon does not move and stays optically aligned with the gear.

## Changes

- `native/LocalPackage/Sources/UserInterface/Views/HeaderBar.swift`
  - New `private static let refreshArcCenter = UnitPoint(x: 0.5, y: 0.558)`, documented with the measurement that produced it and the note that only an SF Symbols redesign of the glyph should move it.
  - The spinning branch's `.rotationEffect` now passes `anchor: Self.refreshArcCenter`.

This is the only rotated glyph in `native/` — `grep -rn "rotationEffect" native/` returns just this call site — so there is nothing else to correct.

## Assumptions

- **The constant is tuned for the 12 pt we draw, not averaged across sizes.** The issue's table gives arc-center ratios of 0.5535 / 0.5578 / 0.5591 / 0.5577 at 11 / 12 / 18 / 24 pt. `0.558` is the 12 pt value (residual < 0.01 pt); at 11 pt it would be ~0.06 pt off, just past the issue's 0.05 pt bar. Since this button is fixed at `size: 12` that is not a live concern, and the code comment says to re-measure if the anchor is ever reused at a very different size. I did not average the four rows, which would trade our exact size for sizes we do not draw.
- Left the constant private to `HeaderBar` rather than promoting it to a shared `Theme/` constant — there is one consumer, and `UserInterface` is views-only.
- No test target added: there is no `UserInterfaceTests` target and the issue explicitly does not ask for one.

## How to verify

**I could not run any of this.** The harness VM is Linux — no Swift toolchain (`swift: command not found`), no AppKit, no SwiftUI. Every number below is either quoted from the issue or derived from it; all three checks need a Mac or CI.

**1. Probe — pivot error before/after.** The issue's probe measures the glyph, which the patch does not change; what changed is the pivot, so the after-check is the residual against the anchor actually used. Replace the final `print` in the issue's probe with:

```swift
    let anchorY = 0.558                      // Self.refreshArcCenter.y
    print(String(format: "arc center y %.3f | box %.3f | old pivot dy %+.3f | new pivot dy %+.3f",
                 c.cy, Double(size.height),
                 c.cy - Double(size.height) / 2,
                 c.cy - anchorY * Double(size.height)))
```

Expected from the issue's own measurements: `old pivot dy +0.860`, `new pivot dy +0.000` — inside the ≤ 0.05 pt bar. Please confirm the run rather than the arithmetic.

**2. Probe — the rotation itself.** Stronger, and the check I would actually trust, since it exercises `rotationEffect(_:anchor:)` instead of re-deriving a constant: render the view *rotated* at several angles inside a fixed frame (so nothing clips) and fit the arc each time. The fitted center must not move.

```swift
MainActor.assumeIsolated {
    for deg in stride(from: 0.0, through: 315.0, by: 45.0) {
        let view = Image(systemName: "arrow.clockwise")
            .font(.system(size: 12, weight: .semibold))
            .rotationEffect(.degrees(deg), anchor: UnitPoint(x: 0.5, y: 0.558))
            .frame(width: 40, height: 40)
        guard let (_, all) = pixels(view, scale: 8) else { fatalError("render failed") }
        var p = all, c = fitCircle(p)
        for _ in 0..<6 {                     // same arrowhead trim as the issue's probe
            let res = p.map { abs((($0.0 - c.cx) * ($0.0 - c.cx)
                + ($0.1 - c.cy) * ($0.1 - c.cy)).squareRoot() - c.r) }
            let cut = res.sorted()[Int(Double(res.count) * 0.6)]
            let keep = zip(p, res).filter { $0.1 <= cut }.map { $0.0 }
            if keep.count < 20 { break }
            p = keep; c = fitCircle(p)
        }
        print(String(format: "%6.1f°  center (%.3f, %.3f)", deg, c.cx, c.cy))
    }
}
```

Before the patch (drop the `anchor:` argument) the printed center should trace a ~1.7 pt circle; after, it should be constant to well under 0.05 pt across all eight angles.

**3. App.** `cd native && xcodegen generate && open Tokcat.xcodeproj`, run, press Refresh with a real quota fetch in flight: the spin should read as in-place rotation, and the icon at rest must sit exactly where it does on `main` (compare against the gear's optical alignment).

**4. CI** must show green — `swift build`, `swift test`, and the xcodegen app build. `UserInterface` is not covered by either test target, so CI's job here is proving the file still compiles; `rotationEffect(_:anchor:)` and `UnitPoint` are both macOS 10.15+, well under the macOS 13 floor.

## Risks / follow-ups

- **Ink now sweeps ~0.86 pt lower.** Rotating about a pivot below the box center moves the swept disc down; the arrowhead can extend marginally further below the layout box than it used to. Nothing clips it (`.buttonStyle(.borderless)`, no `clipShape` on this path) and the swept radius about the true arc center is smaller than about the box center, so I expect no visible change — but it is the one thing worth a glance in the running app if the spin looks like it crowds the row.
- The constant is empirical. If SF Symbols reshapes `arrow.clockwise` in a future macOS, the anchor drifts silently — there is no test that would catch it. A `UserInterfaceTests` target running the probe above as an assertion would, if you ever want one; out of scope here.

Closes #86

<!-- claude-harness kind=DISPATCH issue=86 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCruLBzWpmdmH4ykLUMiV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCruLBzWpmdmH4ykLUMiV3)_