### PR TITLE
harness: merge under a dedicated PAT so the wrap-up event fires

### DIFF
--- a/.claude/harness/README.md
+++ b/.claude/harness/README.md
@@ -35,9 +35,10 @@
 | --- | --- |
 | `.github/workflows/claude-dispatch.yml` | `issues.labeled(claude)` → 세션 발화 + 링크 코멘트. `workflow_dispatch`(DISPATCH/DRY_RUN)로 수동 실행 가능 |
 | `.github/workflows/claude-followup.yml` | 오너의 `@claude` 코멘트/리뷰 → 후속 세션. 시간당 3회 상한 |
-| `.github/workflows/claude-merge-gate.yml` | 오너 승인(리뷰 Approve / `approved` 라벨) → auto-merge. 라벨 제거·변경 요청·새 푸시 시 해제. 머지되면 연결 이슈를 닫고 라벨 정리 |
+| `.github/workflows/claude-merge-gate.yml` | 오너 승인(리뷰 Approve / `approved` 라벨) → auto-merge. 라벨 제거·변경 요청·새 푸시 시 해제. 머지는 `HARNESS_MERGE_TOKEN`(전용 PAT)으로 수행하고, 머지되면 연결 이슈를 닫고 라벨 정리 |
 | `scripts/claude-harness/build-payload.py` | 이슈/PR + 토론 + 문서·스펙을 한 텍스트로 조립 |
 | `scripts/claude-harness/fire.sh` | `/fire` 호출, 429/5xx 재시도, 세션 ID/URL 출력 |
+| `scripts/claude-harness/finish.sh` | 머지된 PR의 연결 이슈를 닫고 하네스 라벨(`claude`, `claude:*`) 제거. 멱등 |
 | `.claude/harness/ROUTINE_PROMPT.md` | 이슈 위임 세션이 따르는 지침의 원본. 클론에 있으면 claude.ai에 저장된 사본보다 우선 |
 | `.claude/harness/REVIEW_PROMPT.md` | PR 자동 리뷰 세션의 지침 원본 (같은 우선순위 규칙) |
 
@@ -56,13 +57,26 @@
    gh secret set CLAUDE_ROUTINE_FIRE_TOKEN -R handlecusion/tokcat   # sk-ant-oat01-…
    ```
    토큰 재발급은 같은 화면의 *Regenerate* — 이전 토큰은 즉시 무효.
-3. **저장소 설정**(이미 적용됨): *Allow auto-merge* 켜기, 룰셋 `protect-main`에 필수 상태 체크
+3. **머지 전용 PAT** (`HARNESS_MERGE_TOKEN`): fine-grained PAT, 리소스 오너 `handlecusion`,
+   저장소는 `handlecusion/tokcat` **하나만**, 권한은 Contents / Issues / Pull requests = Read and write
+   (Workflows는 **주지 않는다** — 아래 이유). 만료 2027-09-06, 이름 `tokcat-harness-merge`.
+   ```sh
+   gh secret set HARNESS_MERGE_TOKEN -R handlecusion/tokcat   # github_pat_…
+   ```
+   **왜 필요한가**: GitHub은 `GITHUB_TOKEN`이 한 일에 대해 워크플로우 이벤트를 발화하지 않는다.
+   github-actions[bot]이 머지하면 `pull_request_target: closed`가 오지 않아 "이슈 닫기 + 라벨 정리"
+   스텝이 영원히 skip된다(#86에서 실측 — 이슈는 `Closes #N`으로 닫혔지만 라벨이 남았다).
+   PAT로 머지하면 이벤트가 정상 발화한다. Workflows 권한을 뺐기 때문에 `.github/workflows/**`를
+   건드리는 PR은 PAT 머지가 거부되고, 게이트가 `GITHUB_TOKEN`으로 폴백한 뒤 정리를 같은 런에서
+   직접 실행한다(`finish.sh`). 시크릿이 없으면 폴백 경로로만 동작한다 — 승인이 막히지는 않는다.
+   **부수 효과**: PAT 머지는 실제 사용자 푸시이므로 머지 후 `push: main` CI가 한 번 더 돈다.
+4. **저장소 설정**(이미 적용됨): *Allow auto-merge* 켜기, 룰셋 `protect-main`에 필수 상태 체크
    `Frontend typecheck` / `Rust check` / `Swift build + test` 추가. CI 잡 이름을 바꾸면 룰셋도 같이 바꿀 것.
-4. 세션이 GitHub에 쓰려면 claude.ai 계정에 GitHub이 연결돼 있어야 한다 (Claude GitHub App — 2026-08-30 연결 완료,
+5. 세션이 GitHub에 쓰려면 claude.ai 계정에 GitHub이 연결돼 있어야 한다 (Claude GitHub App — 2026-08-30 연결 완료,
    앱은 `handlecusion` 계정 전체 저장소에 설치됨). 클라우드 VM에는 `gh`가 **없고** 내장 GitHub MCP 도구
    (`add_issue_comment`, `issue_write`, `create_pull_request`, `pull_request_review_write`, …)로 쓴다.
 
-5. **루틴 (PR 자동 리뷰)**: https://claude.ai/code/routines/trig_01BswRvckXcbV6xSM9CkLQxQ — "tokcat · PR auto-review".
+6. **루틴 (PR 자동 리뷰)**: https://claude.ai/code/routines/trig_01BswRvckXcbV6xSM9CkLQxQ — "tokcat · PR auto-review".
    GitHub 트리거 `pull_request.opened` (Claude GitHub App 웹훅, Actions 불필요).
    **실측 제약(2026-08-31)**: 구독을 걸어도 `ready_for_review`·`reopened`는 세션을 만들지 않았고
    `opened`만 전달됐다(#75–#79에서 5/5). 즉 **웹훅 생성 이전에 열린 PR과 draft→ready 전환 PR은
@@ -82,7 +96,8 @@
   로컬에서 `GH_REPO=handlecusion/tokcat scripts/claude-harness/build-payload.py --kind DRY_RUN --issue N > p.txt && scripts/claude-harness/fire.sh p.txt`).
   세션이 이슈에 "harness dry run OK" 코멘트를 남기면 경로 전체가 살아 있는 것.
   (2026-08-30 E2E 검증: #70 DRY_RUN, #71→PR #72 — 라벨 → 세션 → PR+인라인 셀프 리뷰 → `@claude` 리뷰 반영 →
-  `approved` → auto-merge. 머지는 github-actions[bot]이 수행하므로 `issues: write` 없이는 `Closes #N`이 안 닫힌다.)
+  `approved` → auto-merge. 2026-09-06 재검증: #86→PR #87. 이때 머지가 github-actions[bot] 명의라
+  `closed` 이벤트가 발화하지 않아 라벨 정리 스텝이 skip되는 걸 발견 → 머지를 `HARNESS_MERGE_TOKEN`으로 옮겼다.)
 - **재실행**: `claude:running`을 뗀 뒤, `claude` 라벨을 떼었다가 다시 붙인다(라벨 *추가* 이벤트가 트리거).
 - **질문 답변**: `claude:needs-info`가 붙어 있는 동안은 오너의 아무 코멘트나 후속 세션을 띄운다. 그 외에는
   코멘트/리뷰(인라인 코멘트 포함) 어딘가에 `@claude`가 있어야 한다. Claude 글을 Quote-reply 해도 된다.
@@ -95,9 +110,10 @@
   세션이 안 뜨는데 코멘트도 없다면 워크플로우 런 로그(`🛰️ … 세션을 띄우지 못했습니다` 코멘트에 링크).
 - **한도**: 루틴 런은 계정별 일일 상한이 있고 구독 사용량을 쓴다. `fire.sh`는 429/503/무응답만 재시도한다(`/fire`는
   멱등이 아니라 5xx 재시도는 세션을 두 개 만들 수 있음). 실패 코멘트에 세션 링크가 있으면 라벨을 다시 붙이지 말 것.
-- **지켜볼 것**: (1) auto-merge로 머지된 커밋은 GITHUB_TOKEN 이벤트라 `push: main` CI가 돌지 않는다(PR CI가 이미 통과).
-  (2) 룰셋의 `require_extra_approval_for_unattributed_changes`가 Claude 커밋(작성자 귀속 문제)에 걸려 auto-merge가
-  멈추면 그 옵션을 끄거나 커밋 작성자를 오너로 맞춘다. 첫 실제 PR에서 확인할 것.
+- **지켜볼 것**: (1) PAT 머지는 실제 사용자 푸시라 머지 후 `push: main` CI가 한 번 더 돈다(PR CI와 중복).
+  폴백(GITHUB_TOKEN) 머지에서는 여전히 안 돈다. (2) 룰셋의 `require_extra_approval_for_unattributed_changes`가
+  Claude 커밋(작성자 귀속 문제)에 걸려 auto-merge가 멈추면 그 옵션을 끄거나 커밋 작성자를 오너로 맞춘다.
+  (3) PAT 만료는 2027-09-06 — 만료되면 게이트는 폴백 경로로 조용히 내려간다(런 로그에 `::warning::`).
 
 ## 보안 경계
 

--- a/.github/workflows/claude-merge-gate.yml
+++ b/.github/workflows/claude-merge-gate.yml
@@ -13,6 +13,14 @@ name: Claude harness · merge gate
 # removed, the owner requests changes or dismisses their review, or new commits
 # are pushed — the owner re-approves what they actually reviewed.
 #
+# The merge itself runs under HARNESS_MERGE_TOKEN, a fine-grained PAT scoped to
+# this repo (contents + issues + pull-requests, read/write). It is not cosmetic:
+# GitHub dispatches no workflow events for anything GITHUB_TOKEN does, so a
+# github-actions[bot] merge never fires `pull_request_target: closed` and the
+# wrap-up below never runs — that is how #86 stayed labelled after merging. The
+# PAT deliberately has no Workflows permission, so a PR touching
+# .github/workflows/** falls back to GITHUB_TOKEN and wraps up in-step instead.
+#
 # A Claude cloud session acts under the owner's identity but *through the Claude
 # GitHub App*; a label applied that way is refused, so a session can never
 # approve its own work.
@@ -65,6 +73,10 @@ jobs:
       REVIEW_STATE: ${{ github.event.review.state || '' }}
       HARNESS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Decide
         id: decide
         run: |
@@ -110,6 +122,8 @@ jobs:
 
       - name: Enable auto-merge (merges when CI is green)
         if: steps.decide.outputs.mode == 'approve'
+        env:
+          MERGE_TOKEN: ${{ secrets.HARNESS_MERGE_TOKEN }}
         run: |
           state=$(gh pr view "$PR" --json state,isDraft,mergeStateStatus --jq '"\(.state) draft=\(.isDraft) merge=\(.mergeStateStatus)"')
           echo "PR #$PR: $state"
@@ -117,17 +131,50 @@ jobs:
             OPEN\ draft=false*) ;;
             *) echo "::error::PR is not an open, non-draft PR ($state)"; exit 1 ;;
           esac
-          if ! gh pr merge "$PR" --auto --merge; then
-            # Auto-merge is refused when nothing is pending (checks already green): merge directly.
-            gh pr merge "$PR" --merge
+
+          # Merge as a real user (the PAT) so the resulting `closed` event fires
+          # the wrap-up run; GITHUB_TOKEN merges dispatch nothing. The PAT holds
+          # no Workflows permission, so it is refused on PRs that touch
+          # .github/workflows/** — fall back rather than leave an approved PR
+          # stuck, and wrap up in-step since no event will come.
+          merge() {
+            # $1 token, rest: gh pr merge args
+            local token=$1; shift
+            GH_TOKEN="$token" gh pr merge "$PR" "$@"
+          }
+          via=pat
+          if [ -z "${MERGE_TOKEN:-}" ]; then
+            echo "::warning::HARNESS_MERGE_TOKEN is not set — merging as github-actions[bot]; the closed event will not fire"
+            via=actions; MERGE_TOKEN="$GH_TOKEN"
           fi
+          # --auto is refused when nothing is pending (checks already green): merge directly.
+          if ! merge "$MERGE_TOKEN" --auto --merge && ! merge "$MERGE_TOKEN" --merge; then
+            if [ "$via" = pat ]; then
+              echo "::warning::the PAT could not merge (a PR touching .github/workflows/** needs a Workflows permission it does not have) — retrying as github-actions[bot]"
+              via=actions
+              merge "$GH_TOKEN" --auto --merge || merge "$GH_TOKEN" --merge
+            else
+              exit 1
+            fi
+          fi
+
           if [ "$(gh pr view "$PR" --json state --jq .state)" = "MERGED" ]; then
             how="CI가 이미 통과해 즉시 머지했습니다."
+            merged=yes
           else
             how="자동 머지 예약 — 필수 CI 체크가 모두 통과하면 GitHub이 main에 머지합니다. 그 전에 새 커밋이 푸시되면 승인은 해제됩니다."
+            merged=no
+            [ "$via" = pat ] || how="$how (github-actions[bot]로 예약되어 머지 후 이슈 정리는 자동으로 돌지 않습니다.)"
           fi
           gh api -X POST "repos/$GH_REPO/issues/$PR/comments" \
             -f body="$(printf '✅ **Claude harness** — 오너 승인 확인 (%s). %s\n- 런: %s\n\n<!-- claude-harness kind=MERGE_GATE issue=%s -->' "$EVENT" "$how" "$HARNESS_RUN_URL" "$PR")" --silent
+
+          # Merged right here: no `closed` event is coming for this run's own
+          # merge when it went through GITHUB_TOKEN, and an idempotent extra
+          # wrap-up costs nothing when it does.
+          if [ "$merged" = yes ]; then
+            scripts/claude-harness/finish.sh "$PR"
+          fi
 
       - name: Withdraw approval
         if: steps.decide.outputs.mode == 'withdraw'
@@ -147,25 +194,7 @@ jobs:
 
       - name: Merged → close the linked issue and clear harness labels
         if: steps.decide.outputs.mode == 'finish'
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          issue=$(printf '%s' "$PR_BODY" | grep -oE 'claude-harness[^>]*issue=[0-9]+' | grep -oE '[0-9]+$' | head -1)
-          [ -n "$issue" ] || issue=$(printf '%s' "$HEAD_REF" | grep -oE 'issue-[0-9]+$' | grep -oE '[0-9]+')
-          [ -n "$issue" ] || { echo "no linked issue found in PR body/branch — nothing to close"; exit 0; }
-          state=$(gh api "repos/$GH_REPO/issues/$issue" --jq .state)
-          for l in 'claude%3Apr-open' 'claude%3Arunning' 'claude%3Aneeds-info'; do
-            gh api -X DELETE "repos/$GH_REPO/issues/$issue/labels/$l" --silent 2>/dev/null || true
-          done
-          if [ "$state" = "open" ]; then
-            gh api -X POST "repos/$GH_REPO/issues/$issue/comments" \
-              -f body="$(printf '✅ **Claude harness** — PR #%s가 main에 머지되어 이 이슈를 닫습니다.\n\n<!-- claude-harness kind=MERGE_GATE issue=%s -->' "$PR" "$issue")" --silent
-            gh api -X PATCH "repos/$GH_REPO/issues/$issue" -f state=closed -f state_reason=completed --silent
-            echo "closed #$issue"
-          else
-            echo "#$issue already $state"
-          fi
+        run: scripts/claude-harness/finish.sh "$PR"
 
       - name: Report failure on the PR
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,11 +120,19 @@ Owner-only automation, documented in `.claude/harness/README.md`:
   self-review note. Reply with `@claude` to continue (`claude-followup.yml`).
 - Merge gate (`claude-merge-gate.yml`): owner approval (review **Approve**, or the
   `approved` label for Claude's own PRs) enables auto-merge; the `protect-main`
-  ruleset requires the three CI jobs, so nothing lands before CI is green.
+  ruleset requires the three CI jobs, so nothing lands before CI is green. The
+  merge runs under `HARNESS_MERGE_TOKEN` — a merge performed with `GITHUB_TOKEN`
+  dispatches no events, so the `pull_request_target: closed` wrap-up
+  (`scripts/claude-harness/finish.sh`: close the issue, drop the harness labels)
+  would never run. That PAT has no Workflows permission on purpose, so a PR
+  touching `.github/workflows/**` falls back to `GITHUB_TOKEN` and wraps up
+  in-step.
 - Every opened PR also gets an automatic COMMENT review from a second routine
   (`.claude/harness/REVIEW_PROMPT.md`) via a GitHub trigger — it never approves.
 - Secrets: `CLAUDE_ROUTINE_FIRE_URL`, `CLAUDE_ROUTINE_FIRE_TOKEN` (per-routine
-  token; it can only fire that routine). No Claude credentials on runners.
+  token; it can only fire that routine), `HARNESS_MERGE_TOKEN` (fine-grained PAT,
+  contents/issues/pull-requests on this repo only, expires 2027-09-06). No Claude
+  credentials on runners.
 - Sessions write to GitHub as the owner *via the Claude GitHub App*
   (`performed_via_github_app`); the workflows use that to tell a human apart
   from a session, so never post `@claude` or the `approved` label from a session.

--- a/scripts/claude-harness/finish.sh
+++ b/scripts/claude-harness/finish.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Wrap up a merged harness PR: clear the harness labels off the linked issue and
+# close it. Idempotent — safe to run twice on the same PR.
+#
+#   GH_TOKEN  a token with issues:write on this repo
+#   GH_REPO   owner/name
+#
+# Usage: finish.sh <pr-number>
+#
+# Two call sites, because a merge reaches us two ways (see claude-merge-gate.yml):
+#   • the gate merged the PR itself in-step (CI was already green)
+#   • GitHub auto-merged it later and the `pull_request_target: closed` event
+#     brought us back
+set -euo pipefail
+
+pr="${1:?pr number}"
+: "${GH_REPO:?GH_REPO is not set}"
+
+body=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.body // ""')
+head=$(gh api "repos/$GH_REPO/pulls/$pr" --jq '.head.ref // ""')
+
+# The marker the session writes into every PR body is authoritative; the branch
+# name is the fallback for a PR whose body was edited.
+issue=$(printf '%s' "$body" | grep -oE 'claude-harness[^>]*issue=[0-9]+' | grep -oE '[0-9]+$' | head -1 || true)
+[ -n "$issue" ] || issue=$(printf '%s' "$head" | grep -oE 'issue-[0-9]+$' | grep -oE '[0-9]+' || true)
+[ -n "$issue" ] || { echo "no linked issue in PR #$pr body/branch — nothing to finish"; exit 0; }
+
+# `claude` goes too: leaving the trigger label on a closed issue makes a re-run
+# ("remove, then re-add") look like a no-op.
+for label in 'claude' 'claude%3Apr-open' 'claude%3Arunning' 'claude%3Aneeds-info'; do
+  gh api -X DELETE "repos/$GH_REPO/issues/$issue/labels/$label" --silent 2>/dev/null || true
+done
+
+state=$(gh api "repos/$GH_REPO/issues/$issue" --jq .state)
+if [ "$state" = "open" ]; then
+  gh api -X POST "repos/$GH_REPO/issues/$issue/comments" \
+    -f body="$(printf '✅ **Claude harness** — PR #%s가 main에 머지되어 이 이슈를 닫습니다.\n\n<!-- claude-harness kind=MERGE_GATE issue=%s -->' "$pr" "$issue")" --silent
+  gh api -X PATCH "repos/$GH_REPO/issues/$issue" -f state=closed -f state_reason=completed --silent
+  echo "closed #$issue, harness labels cleared"
+else
+  echo "#$issue already $state, harness labels cleared"
+fi


### PR DESCRIPTION
## Problem

Verified on #86 → #87: the gate's `Merged → close the linked issue and clear harness labels` step is **dead code**. `gh pr merge --auto` ran as `github-actions[bot]`, GitHub dispatches no workflow events for `GITHUB_TOKEN` actions, so `pull_request_target: closed` never fired — there is no such run in the workflow's history. The issue still closed (GitHub resolves `Closes #N` itself), but `claude` and `claude:pr-open` stayed on it.

## Change

- Merge under `HARNESS_MERGE_TOKEN`, a fine-grained PAT (resource owner `handlecusion`, repo `handlecusion/tokcat` only, Contents/Issues/Pull requests RW, expires 2027-09-06). A merge attributed to a real user fires the `closed` event.
- The PAT has **no Workflows permission** on purpose, so it cannot merge a PR that edits `.github/workflows/**` (this PR, for example). That path falls back to `GITHUB_TOKEN` and runs the wrap-up in-step, so approval is never a dead end. Same fallback when the secret is absent or expired (`::warning::` in the run log).
- Wrap-up extracted to `scripts/claude-harness/finish.sh` — idempotent, two call sites (in-step after an immediate merge, and the `closed` event for a deferred auto-merge). It now also drops the `claude` trigger label; leaving it on a closed issue made the documented re-run ("remove, then re-add") look like a no-op.
- Docs: `AGENTS.md` + `.claude/harness/README.md` (new secret, why it exists, and the new side effect that harness merges now trigger a `push: main` CI run).

## Verification

- `scripts/claude-harness/finish.sh 87` run locally against the already-merged PR #87: `#86 already closed, harness labels cleared` — idempotent, no spurious comment.
- YAML parses; every `run:` block passes `bash -n`.
- The end-to-end proof is the next harness PR: its merge must produce a `pull_request_target: closed` gate run whose wrap-up step is `success`, not `skipped`.