### PR TITLE
Give the chart tooltip fixed token and cost columns

### DIFF
--- a/native/LocalPackage/Package.swift
+++ b/native/LocalPackage/Package.swift
@@ -78,5 +78,12 @@ let package = Package(
             resources: [.copy("Resources/golden.json")],
             swiftSettings: swiftSettings
         ),
+        // View-geometry budgets that would otherwise only be checkable by
+        // eye: measured with the same AppKit font metrics the views draw.
+        .testTarget(
+            name: "UserInterfaceTests",
+            dependencies: ["UserInterface"],
+            swiftSettings: swiftSettings
+        ),
     ]
 )

--- a/native/LocalPackage/Package.swift
+++ b/native/LocalPackage/Package.swift
@@ -78,8 +78,9 @@ let package = Package(
             resources: [.copy("Resources/golden.json")],
             swiftSettings: swiftSettings
         ),
-        // View-geometry budgets that would otherwise only be checkable by
-        // eye: measured with the same AppKit font metrics the views draw.
+        // View geometry that would otherwise only be checkable by eye: width
+        // budgets from the same AppKit font metrics the views draw, plus an
+        // ImageRenderer pass that measures the drawn ink of a real view.
         .testTarget(
             name: "UserInterfaceTests",
             dependencies: ["UserInterface"],

--- a/native/LocalPackage/Sources/UserInterface/Theme/ClientStyle.swift
+++ b/native/LocalPackage/Sources/UserInterface/Theme/ClientStyle.swift
@@ -59,6 +59,11 @@ public enum ClientRegistry {
         "aside": ("Aside", "#14b8a6", nil),
     ]
 
+    /// Every client id the registry knows, in a stable order. The tooltip
+    /// width budget in UserInterfaceTests derives the widest name the tooltip
+    /// can draw from this, so the budget cannot drift when a client is added.
+    static var allIDs: [String] { entries.keys.sorted() }
+
     public static func style(for id: String) -> ClientStyle {
         if let entry = entries[id] {
             // iconType is the registry's claim; ClientIconView still falls

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -368,17 +368,13 @@ struct TooltipSegmentRows: View {
 enum TooltipMetrics {
     static let width: CGFloat = 190
     static let padding: CGFloat = 8
-    /// Gap between the label, tokens and cost columns.
-    ///
-    /// Pinned by the widest name `ClientRegistry` can draw: the label cell
-    /// gets what the two number columns and these two gaps leave, and at 6 pt
-    /// that was 62.83 pt against the 63.13 pt "OpenCode" wants — 0.30 pt short,
-    /// i.e. the longest client name would have arrived truncated on the
-    /// screenshot's own numbers. 5 pt buys back the 2 pt (see
-    /// `TooltipColumnLayoutTests.columnsFitTheTooltipAtTodaysWidth`, which
-    /// fails if a future name or a wider font eats the margin again), and is
-    /// the same gap the dot already keeps from the label.
-    static let columnSpacing: CGFloat = 5
+    /// Gap between the label, tokens and cost columns. 6 pt is the value the
+    /// owner rendered and measured on macOS 15; the widest name the registry
+    /// can draw ("OpenCode") overflows the label cell by 0.30 pt at the
+    /// screenshot's numbers and truncates, which is this PR's chosen failure
+    /// mode — see `TooltipColumnLayoutTests.columnsFitTheTooltipAtTodaysWidth`,
+    /// which records that overflow and fails if it ever grows visible.
+    static let columnSpacing: CGFloat = 6
     static let dotSize: CGFloat = 6
     static let dotLabelSpacing: CGFloat = 5
     static let segmentFontSize: CGFloat = 10

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -246,41 +246,15 @@ struct UsageBarChart: View {
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             Divider()
-            // Three columns — dot+name | tokens | cost. One right-aligned
-            // "<tokens> · <cost>" string per row put every number at a
-            // different x, because only the row's right edge was fixed and
-            // everything left of it floated with that row's cost width. Grid
-            // sizes each column to its widest cell, so the numbers now read
-            // straight down. The label cell is the only flexible one, so it
-            // absorbs the slack and keeps the number columns flush right,
-            // in line with the total row above.
-            Grid(alignment: .leading,
-                 horizontalSpacing: TooltipMetrics.columnSpacing,
-                 verticalSpacing: 5) {
-                ForEach(bar.segments) { segment in
-                    let style = ClientRegistry.style(for: segment.clientId)
-                    GridRow {
-                        HStack(spacing: TooltipMetrics.dotLabelSpacing) {
-                            Circle().fill(style.color)
-                                .frame(width: TooltipMetrics.dotSize,
-                                       height: TooltipMetrics.dotSize)
-                            Text(style.shortName)
-                                .font(.system(size: TooltipMetrics.segmentFontSize,
-                                              weight: .medium))
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                            Spacer(minLength: 0)
-                        }
-                        // .fixedSize() over .minimumScaleFactor: a cell that
-                        // shrinks its own text re-breaks the column it sits
-                        // in. A row that genuinely does not fit truncates its
-                        // client name instead; the numbers never move.
-                        numberCell(NumberText.exactTokens(segment.tokens))
-                        numberCell(Formatters.formatCost(segment.cost))
-                    }
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            TooltipSegmentRows(rows: bar.segments.map { segment -> TooltipSegmentRows.Row in
+                let style = ClientRegistry.style(for: segment.clientId)
+                return TooltipSegmentRows.Row(
+                    id: segment.id,
+                    name: style.shortName,
+                    tokens: NumberText.exactTokens(segment.tokens),
+                    cost: Formatters.formatCost(segment.cost),
+                    color: style.color)
+            })
         }
         .padding(TooltipMetrics.padding)
         .frame(width: TooltipMetrics.width)
@@ -300,13 +274,90 @@ struct UsageBarChart: View {
             y: max(52, barTop - 60))
         .allowsHitTesting(false)
     }
+}
 
-    private func numberCell(_ text: String) -> some View {
+/// The tooltip's per-client rows: three columns, dot+name | tokens | cost.
+///
+/// One right-aligned `"<tokens> · <cost>"` string per row put every number at
+/// a different x, because only the row's right edge was fixed and everything
+/// left of it floated with that row's cost width (issue #89). `Grid` sizes
+/// each column to its widest cell, so the numbers now read straight down. The
+/// label cell is the only flexible one, so it absorbs the slack and keeps the
+/// number columns flush right, in line with the total row above.
+///
+/// It is a view of its own — and deliberately in this file, next to its only
+/// caller — so `TooltipRenderMeasurementTests` renders the rows the tooltip
+/// actually draws rather than a copy of the layout that can drift from them.
+struct TooltipSegmentRows: View {
+    struct Row: Identifiable {
+        let id: String
+        let name: String
+        let tokens: String
+        let cost: String
+        let color: Color
+    }
+
+    /// One of the grid's three columns.
+    enum Column {
+        case label
+        case tokens
+        case cost
+    }
+
+    let rows: [Row]
+
+    /// Draws only this column's ink, leaving every cell's size and position
+    /// untouched (the other two get `.opacity(0)`). `nil` — the app's only
+    /// value — draws all three. The render measurement sets it so a column's
+    /// right edge can be read straight off the bitmap without having to tell
+    /// two columns' glyphs apart.
+    var inkedColumn: Column? = nil
+
+    var body: some View {
+        Grid(alignment: .leading,
+             horizontalSpacing: TooltipMetrics.columnSpacing,
+             verticalSpacing: 5) {
+            ForEach(rows) { row in
+                GridRow {
+                    HStack(spacing: TooltipMetrics.dotLabelSpacing) {
+                        Circle().fill(row.color)
+                            .frame(width: TooltipMetrics.dotSize,
+                                   height: TooltipMetrics.dotSize)
+                        Text(row.name)
+                            .font(.system(size: TooltipMetrics.segmentFontSize,
+                                          weight: .medium))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        // The one horizontally flexible cell: it takes the
+                        // slack, which is what holds the two number columns
+                        // against the content box's right edge.
+                        Spacer(minLength: 0)
+                    }
+                    .opacity(ink(.label))
+                    // .fixedSize() over .minimumScaleFactor: a cell that
+                    // shrinks its own text re-breaks the column it sits in. A
+                    // row that genuinely does not fit truncates its client
+                    // name instead; the numbers never move.
+                    numberCell(row.tokens, column: .tokens)
+                    numberCell(row.cost, column: .cost)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func ink(_ column: Column) -> Double {
+        inkedColumn == nil || inkedColumn == column ? 1 : 0
+    }
+
+    private func numberCell(_ text: String, column: Column) -> some View {
         Text(text)
             .font(.system(size: TooltipMetrics.segmentFontSize))
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .fixedSize()
+            .opacity(ink(column))
+            // Read by `Grid` off the cell view itself, so it stays outermost.
             .gridColumnAlignment(.trailing)
     }
 }

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -328,10 +328,15 @@ struct TooltipSegmentRows: View {
                                           weight: .medium))
                             .lineLimit(1)
                             .truncationMode(.tail)
-                        // The one horizontally flexible cell: it takes the
-                        // slack, which is what holds the two number columns
-                        // against the content box's right edge.
-                        Spacer(minLength: 0)
+                            // The name itself is the flexible thing, so this
+                            // cell still takes the grid's slack and still holds
+                            // the two number columns against the content box's
+                            // right edge. A trailing `Spacer(minLength: 0)` did
+                            // the same job but cost a second `HStack` gap
+                            // before it — 5 pt of nothing, charged to the
+                            // cell's ideal width, which is what pushed the
+                            // widest client name into the ellipsis.
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .opacity(ink(.label))
                     // .fixedSize() over .minimumScaleFactor: a cell that
@@ -368,13 +373,19 @@ struct TooltipSegmentRows: View {
 enum TooltipMetrics {
     static let width: CGFloat = 190
     static let padding: CGFloat = 8
-    /// Gap between the label, tokens and cost columns. 6 pt is the value the
-    /// owner rendered and measured on macOS 15; the widest name the registry
-    /// can draw ("OpenCode") overflows the label cell by 0.30 pt at the
-    /// screenshot's numbers and truncates, which is this PR's chosen failure
-    /// mode — see `TooltipColumnLayoutTests.columnsFitTheTooltipAtTodaysWidth`,
-    /// which records that overflow and fails if it ever grows visible.
-    static let columnSpacing: CGFloat = 6
+    /// Gap between the label, tokens and cost columns.
+    ///
+    /// Pinned by the widest `shortName` `ClientRegistry` can draw ("OpenCode",
+    /// 52.13 pt, so a 63.25 pt label cell) standing beside the widest token
+    /// column the screenshot produces. At 6 pt the cell's share is 62.83 pt and
+    /// that name loses its tail to the ellipsis; at 5 pt it is 64.83 pt and the
+    /// name renders whole. 5 pt is also what `dotLabelSpacing` already uses, so
+    /// a right-aligned number column is no closer to its neighbour than the dot
+    /// is to the name. Moving this re-budgets
+    /// `TooltipColumnLayoutTests.columnsFitTheTooltipAtTodaysWidth` and is
+    /// measured on the bitmap by
+    /// `TooltipRenderMeasurementTests.widestClientNameRendersUntruncated`.
+    static let columnSpacing: CGFloat = 5
     static let dotSize: CGFloat = 6
     static let dotLabelSpacing: CGFloat = 5
     static let segmentFontSize: CGFloat = 10

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -369,7 +369,16 @@ enum TooltipMetrics {
     static let width: CGFloat = 190
     static let padding: CGFloat = 8
     /// Gap between the label, tokens and cost columns.
-    static let columnSpacing: CGFloat = 6
+    ///
+    /// Pinned by the widest name `ClientRegistry` can draw: the label cell
+    /// gets what the two number columns and these two gaps leave, and at 6 pt
+    /// that was 62.83 pt against the 63.13 pt "OpenCode" wants — 0.30 pt short,
+    /// i.e. the longest client name would have arrived truncated on the
+    /// screenshot's own numbers. 5 pt buys back the 2 pt (see
+    /// `TooltipColumnLayoutTests.columnsFitTheTooltipAtTodaysWidth`, which
+    /// fails if a future name or a wider font eats the margin again), and is
+    /// the same gap the dot already keeps from the label.
+    static let columnSpacing: CGFloat = 5
     static let dotSize: CGFloat = 6
     static let dotLabelSpacing: CGFloat = 5
     static let segmentFontSize: CGFloat = 10

--- a/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
+++ b/native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift
@@ -246,24 +246,44 @@ struct UsageBarChart: View {
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             Divider()
-            ForEach(bar.segments) { segment in
-                let style = ClientRegistry.style(for: segment.clientId)
-                HStack(spacing: 5) {
-                    Circle().fill(style.color).frame(width: 6, height: 6)
-                    Text(style.shortName)
-                        .font(.system(size: 10, weight: .medium))
-                    Spacer(minLength: 8)
-                    Text("\(NumberText.exactTokens(segment.tokens)) · "
-                         + Formatters.formatCost(segment.cost))
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+            // Three columns — dot+name | tokens | cost. One right-aligned
+            // "<tokens> · <cost>" string per row put every number at a
+            // different x, because only the row's right edge was fixed and
+            // everything left of it floated with that row's cost width. Grid
+            // sizes each column to its widest cell, so the numbers now read
+            // straight down. The label cell is the only flexible one, so it
+            // absorbs the slack and keeps the number columns flush right,
+            // in line with the total row above.
+            Grid(alignment: .leading,
+                 horizontalSpacing: TooltipMetrics.columnSpacing,
+                 verticalSpacing: 5) {
+                ForEach(bar.segments) { segment in
+                    let style = ClientRegistry.style(for: segment.clientId)
+                    GridRow {
+                        HStack(spacing: TooltipMetrics.dotLabelSpacing) {
+                            Circle().fill(style.color)
+                                .frame(width: TooltipMetrics.dotSize,
+                                       height: TooltipMetrics.dotSize)
+                            Text(style.shortName)
+                                .font(.system(size: TooltipMetrics.segmentFontSize,
+                                              weight: .medium))
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer(minLength: 0)
+                        }
+                        // .fixedSize() over .minimumScaleFactor: a cell that
+                        // shrinks its own text re-breaks the column it sits
+                        // in. A row that genuinely does not fit truncates its
+                        // client name instead; the numbers never move.
+                        numberCell(NumberText.exactTokens(segment.tokens))
+                        numberCell(Formatters.formatCost(segment.cost))
+                    }
                 }
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(8)
-        .frame(width: 190)
+        .padding(TooltipMetrics.padding)
+        .frame(width: TooltipMetrics.width)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(.thickMaterial)
@@ -275,8 +295,34 @@ struct UsageBarChart: View {
         )
         // Keep the tooltip inside the plot horizontally and above the bar.
         .position(
-            x: min(max(centerX, plotFrame.minX + 95), plotFrame.maxX - 95),
+            x: min(max(centerX, plotFrame.minX + TooltipMetrics.width / 2),
+                   plotFrame.maxX - TooltipMetrics.width / 2),
             y: max(52, barTop - 60))
         .allowsHitTesting(false)
     }
+
+    private func numberCell(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: TooltipMetrics.segmentFontSize))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .fixedSize()
+            .gridColumnAlignment(.trailing)
+    }
+}
+
+/// Geometry of the hover tooltip in `UsageBarChart`. Named so the layout
+/// budget test in UserInterfaceTests measures the same box and the same font
+/// the view draws, instead of a copy of the numbers that can drift from it.
+enum TooltipMetrics {
+    static let width: CGFloat = 190
+    static let padding: CGFloat = 8
+    /// Gap between the label, tokens and cost columns.
+    static let columnSpacing: CGFloat = 6
+    static let dotSize: CGFloat = 6
+    static let dotLabelSpacing: CGFloat = 5
+    static let segmentFontSize: CGFloat = 10
+
+    /// What the three columns and their two gaps have to fit into.
+    static var contentWidth: CGFloat { width - padding * 2 }
 }

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -1,0 +1,165 @@
+import AppKit
+import XCTest
+
+@testable import UserInterface
+
+/// Issue #89: the chart tooltip drew each per-client row as one right-aligned
+/// `"<tokens> · <cost>"` string, so the only fixed thing in the row was its
+/// right edge — both numbers slid left by however wide that row's cost was.
+///
+/// The fix is a three-column `Grid` (dot+name | tokens | cost). `Grid` gives a
+/// column the width of its widest cell and places every cell in it with the
+/// column's alignment, so `Layout` below — column width = max over rows,
+/// trailing-aligned, packed against the content box's right edge — is the
+/// arrangement the view asks for. The alignment then comes for free; what
+/// this test measures with real font metrics is the part that does not:
+/// whether three columns and two gaps still fit the 174 pt content box at
+/// today's 190 pt tooltip width, for the screenshot's rows and for a
+/// deliberately wide one. The running app is the check that `Grid` renders
+/// this arrangement (verification 2 in the PR).
+///
+/// Widths come from `NSAttributedString.size(withAttributes:)`, the way the
+/// measurements in the issue were produced. Two places sum substring widths,
+/// which ignores kerning across the join — good to a fraction of a point,
+/// which is the resolution this budget needs.
+final class TooltipColumnLayoutTests: XCTestCase {
+    private struct Row {
+        let name: String
+        let tokens: String
+        let cost: String
+    }
+
+    /// The four rows in the issue's screenshot (Sep 5).
+    private static let screenshot = [
+        Row(name: "Aside", tokens: "599,788,471", cost: "$152.46"),
+        Row(name: "Claude", tokens: "8,481,070", cost: "$20.22"),
+        Row(name: "Codex", tokens: "4,092,946", cost: "$1.18"),
+        Row(name: "Oh My Pi", tokens: "32,521,315", cost: "$21.24"),
+    ]
+
+    /// A 12-digit token count against a 3-digit cost, per the issue's ask to
+    /// verify a wide case rather than only the screenshot's numbers. The name
+    /// is the longest one in `ClientRegistry`.
+    private static let wide = [
+        Row(name: "Synthetic", tokens: "999,999,999,999", cost: "$152.46"),
+        Row(name: "Codex", tokens: "4,092,946", cost: "$1.18"),
+    ]
+
+    // MARK: - Measurement
+
+    private func width(_ string: String, weight: NSFont.Weight = .regular) -> CGFloat {
+        let font = NSFont.systemFont(ofSize: TooltipMetrics.segmentFontSize, weight: weight)
+        return (string as NSString).size(withAttributes: [.font: font]).width
+    }
+
+    /// Width the dot + client name cell wants before any truncation.
+    private func labelCellWidth(_ name: String) -> CGFloat {
+        TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing + width(name, weight: .medium)
+    }
+
+    /// The Grid arrangement, resolved for a set of rows. All x are measured
+    /// from the left edge of the tooltip's content box.
+    private struct Layout {
+        let tokensColumnRight: CGFloat
+        let tokensColumnLeft: CGFloat
+        let costColumnRight: CGFloat
+        /// What is left for the dot + client name cell.
+        let labelAvailable: CGFloat
+    }
+
+    private func layout(_ rows: [Row]) -> Layout {
+        let tokensColumn = rows.map { width($0.tokens) }.max() ?? 0
+        let costColumn = rows.map { width($0.cost) }.max() ?? 0
+        let costRight = TooltipMetrics.contentWidth
+        let tokensRight = costRight - costColumn - TooltipMetrics.columnSpacing
+        let tokensLeft = tokensRight - tokensColumn
+        return Layout(tokensColumnRight: tokensRight,
+                      tokensColumnLeft: tokensLeft,
+                      costColumnRight: costRight,
+                      labelAvailable: tokensLeft - TooltipMetrics.columnSpacing)
+    }
+
+    private func line(_ label: String, _ values: CGFloat...) -> String {
+        let padded = label.padding(toLength: max(12, label.count), withPad: " ", startingAt: 0)
+        return padded + values.map { String(format: "%8.2f", Double($0)) }.joined()
+    }
+
+    // MARK: - The bug
+
+    /// Documents the cause: with one string per row, the x of both numbers is
+    /// a function of that row's cost width alone.
+    func testSingleStringRowsPutEveryNumberAtADifferentX() {
+        var tokensRight: [CGFloat] = []
+        var costLeft: [CGFloat] = []
+
+        print("old layout — one right-aligned string per row (tokens right, cost left):")
+        for row in Self.screenshot {
+            let right = TooltipMetrics.contentWidth - width(" · " + row.cost)
+            let left = TooltipMetrics.contentWidth - width(row.cost)
+            tokensRight.append(right)
+            costLeft.append(left)
+            print(line(row.name, right, left))
+        }
+
+        let tokensSpread = (tokensRight.max() ?? 0) - (tokensRight.min() ?? 0)
+        let costSpread = (costLeft.max() ?? 0) - (costLeft.min() ?? 0)
+        print(line("spread", tokensSpread, costSpread))
+
+        // Measured at 14.33 pt in the issue. Asserted loosely so a future
+        // font-metric change cannot fail this bit of documentation.
+        XCTAssertGreaterThan(tokensSpread, 5, "the wander this issue is about")
+        XCTAssertGreaterThan(costSpread, 5)
+    }
+
+    // MARK: - The fix
+
+    func testColumnLayoutGivesEveryRowTheSameX() {
+        for rows in [Self.screenshot, Self.wide] {
+            let l = layout(rows)
+            for row in rows {
+                // Trailing alignment inside a column that is as wide as its
+                // widest cell: every row's number ends at the column's x, and
+                // no cell has to be squeezed to get there.
+                XCTAssertLessThanOrEqual(width(row.tokens),
+                                         l.tokensColumnRight - l.tokensColumnLeft)
+                XCTAssertLessThanOrEqual(width(row.cost),
+                                         TooltipMetrics.contentWidth - l.tokensColumnRight
+                                             - TooltipMetrics.columnSpacing)
+            }
+        }
+
+        let l = layout(Self.screenshot)
+        print("new layout — columns (same x for every row):")
+        print(line("tokens", l.tokensColumnLeft, l.tokensColumnRight))
+        print(line("cost", l.costColumnRight))
+    }
+
+    func testColumnsFitTheTooltipAtTodaysWidth() {
+        let l = layout(Self.screenshot)
+        let widest = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
+
+        print(line("screenshot", widest, l.labelAvailable))
+        XCTAssertGreaterThan(l.tokensColumnLeft, 0,
+                             "both number columns must fit the 174 pt content box")
+        XCTAssertGreaterThan(l.labelAvailable, widest,
+                             "the screenshot's rows must fit without truncating a client name")
+    }
+
+    /// The wide case: a 12-digit token count next to a 3-digit cost still
+    /// leaves the label cell its dot and a readable name. Rows wider than
+    /// that truncate the name — the numbers never move.
+    func testWideCaseStillFitsBothNumberColumns() {
+        let l = layout(Self.wide)
+        let shortestPlausibleLabel = labelCellWidth("Amp")
+
+        print(line("wide", shortestPlausibleLabel, l.labelAvailable))
+        XCTAssertGreaterThan(l.tokensColumnLeft, 0,
+                             "both number columns must fit the 174 pt content box")
+        XCTAssertGreaterThan(l.labelAvailable, shortestPlausibleLabel)
+    }
+
+    func testMetricsMatchTheTooltipBox() {
+        XCTAssertEqual(TooltipMetrics.width, 190)
+        XCTAssertEqual(TooltipMetrics.contentWidth, 174)
+    }
+}

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -7,21 +7,19 @@ import Testing
 /// `"<tokens> · <cost>"` string, so the only fixed thing in the row was its
 /// right edge — both numbers slid left by however wide that row's cost was.
 ///
-/// The fix is a three-column `Grid` (dot+name | tokens | cost). `Grid` gives a
-/// column the width of its widest cell and places every cell in it with the
-/// column's alignment, so `Layout` below — column width = max over rows,
-/// trailing-aligned, packed against the content box's right edge — is the
-/// arrangement the view asks for. The alignment then comes for free; what
-/// this suite measures with real font metrics is the part that does not:
-/// whether three columns and two gaps still fit the 174 pt content box at
-/// today's 190 pt tooltip width, for the screenshot's rows and for a
-/// deliberately wide one. The running app is the check that `Grid` renders
-/// this arrangement (verification 2 in the PR).
+/// The fix is a three-column `Grid` (dot+name | tokens | cost). This suite
+/// models the two arrangements over the same rows and measures both with real
+/// AppKit metrics, the way the issue's table was produced: `singleStringXs`
+/// is what the view drew before, `columnXs` is what it asks `Grid` for now.
+/// Asserting the old spread is wide and the new one is zero is the only
+/// formulation that ties an assertion to the change; the rest of the suite
+/// budgets the widths, which is the part that can regress as fonts, names or
+/// magnitudes grow. What no measurement here can settle is whether `Grid`
+/// hands the horizontal slack to the label cell — that is verification 2, in
+/// the running app.
 ///
-/// Widths come from `NSAttributedString.size(withAttributes:)`, the way the
-/// measurements in the issue were produced. Two places sum substring widths,
-/// which ignores kerning across the join — good to a fraction of a point,
-/// which is the resolution this budget needs.
+/// Two places sum substring widths, which ignores kerning across the join —
+/// good to a fraction of a point, the resolution this budget needs.
 @Suite struct TooltipColumnLayoutTests {
     private struct Row {
         let name: String
@@ -37,11 +35,16 @@ import Testing
         Row(name: "Oh My Pi", tokens: "32,521,315", cost: "$21.24"),
     ]
 
+    /// The widest label the tooltip can draw. `ClientStyle.shortName` strips
+    /// only `" CLI" / " Code" / " IDE"`, so `grok`'s "Grok Build" survives
+    /// whole and beats "Synthetic", "OpenClaw", "OpenCode", "KiloCode" and
+    /// "Oh My Pi".
+    private static let widestClientName = "Grok Build"
+
     /// A 12-digit token count against a 3-digit cost, per the issue's ask to
-    /// verify a wide case rather than only the screenshot's numbers. The name
-    /// is the longest one in `ClientRegistry`.
+    /// verify a wide case rather than only the screenshot's numbers.
     private static let wide = [
-        Row(name: "Synthetic", tokens: "999,999,999,999", cost: "$152.46"),
+        Row(name: widestClientName, tokens: "999,999,999,999", cost: "$152.46"),
         Row(name: "Codex", tokens: "4,092,946", cost: "$1.18"),
     ]
 
@@ -57,13 +60,29 @@ import Testing
         TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing + width(name, weight: .medium)
     }
 
-    /// The Grid arrangement, resolved for a set of rows. All x are measured
-    /// from the left edge of the tooltip's content box.
+    private func spread(_ xs: [CGFloat]) -> CGFloat { (xs.max() ?? 0) - (xs.min() ?? 0) }
+
+    /// Where each row's numbers landed under the old arrangement: one
+    /// right-aligned string, so both numbers are pushed left by that row's
+    /// own cost width and by nothing else.
+    private func singleStringXs(_ rows: [Row]) -> (tokensRight: [CGFloat], costLeft: [CGFloat]) {
+        (rows.map { TooltipMetrics.contentWidth - width(" · " + $0.cost) },
+         rows.map { TooltipMetrics.contentWidth - width($0.cost) })
+    }
+
+    /// Where each row's numbers land under the `Grid` arrangement: a column
+    /// as wide as its widest cell, every cell in it trailing-aligned, both
+    /// columns packed against the content box's right edge.
+    private func columnXs(_ rows: [Row]) -> (tokensRight: [CGFloat], costLeft: [CGFloat]) {
+        let l = layout(rows)
+        return (rows.map { _ in l.tokensColumnRight }, rows.map { _ in l.costColumnLeft })
+    }
+
+    /// The resolved column geometry, as x from the content box's left edge.
     private struct Layout {
         let tokensColumnLeft: CGFloat
         let tokensColumnRight: CGFloat
         let costColumnLeft: CGFloat
-        let costColumnRight: CGFloat
         /// What is left for the dot + client name cell.
         let labelAvailable: CGFloat
     }
@@ -71,92 +90,83 @@ import Testing
     private func layout(_ rows: [Row]) -> Layout {
         let tokensColumn = rows.map { width($0.tokens) }.max() ?? 0
         let costColumn = rows.map { width($0.cost) }.max() ?? 0
-        let costRight = TooltipMetrics.contentWidth
-        let tokensRight = costRight - costColumn - TooltipMetrics.columnSpacing
+        let tokensRight = TooltipMetrics.contentWidth - costColumn - TooltipMetrics.columnSpacing
         let tokensLeft = tokensRight - tokensColumn
         return Layout(tokensColumnLeft: tokensLeft,
                       tokensColumnRight: tokensRight,
-                      costColumnLeft: costRight - costColumn,
-                      costColumnRight: costRight,
+                      costColumnLeft: TooltipMetrics.contentWidth - costColumn,
                       labelAvailable: tokensLeft - TooltipMetrics.columnSpacing)
     }
 
     private func line(_ label: String, _ values: CGFloat...) -> String {
-        label.padding(toLength: max(14, label.count), withPad: " ", startingAt: 0)
+        label.padding(toLength: max(16, label.count), withPad: " ", startingAt: 0)
             + values.map { String(format: "%8.2f", Double($0)) }.joined()
     }
 
-    // MARK: - The bug
+    // MARK: - The fix, against the bug
 
-    /// Documents the cause: with one string per row, the x of both numbers is
-    /// a function of that row's cost width alone.
-    @Test func singleStringRowsPutEveryNumberAtADifferentX() {
-        var tokensRight: [CGFloat] = []
-        var costLeft: [CGFloat] = []
+    /// The assertion this PR exists for: over the same rows, the old
+    /// arrangement puts every number at its own x and the new one puts them
+    /// all at a single x per column.
+    @Test func theColumnsCollapseTheWanderToZero() {
+        for (label, rows) in [("screenshot", Self.screenshot), ("wide", Self.wide)] {
+            let old = singleStringXs(rows)
+            let new = columnXs(rows)
 
-        print("#89 old layout — one right-aligned string per row")
-        print("                tokens R  cost L")
-        for row in Self.screenshot {
-            let right = TooltipMetrics.contentWidth - width(" · " + row.cost)
-            let left = TooltipMetrics.contentWidth - width(row.cost)
-            tokensRight.append(right)
-            costLeft.append(left)
-            print(line(row.name, right, left))
-        }
-
-        let tokensSpread = (tokensRight.max() ?? 0) - (tokensRight.min() ?? 0)
-        let costSpread = (costLeft.max() ?? 0) - (costLeft.min() ?? 0)
-        print(line("spread", tokensSpread, costSpread))
-
-        // Measured at 14.33 pt in the issue. Asserted loosely so a future
-        // font-metric change cannot fail this bit of documentation.
-        #expect(tokensSpread > 5, "the wander this issue is about")
-        #expect(costSpread > 5)
-    }
-
-    // MARK: - The fix
-
-    @Test func columnLayoutGivesEveryRowTheSameX() {
-        for rows in [Self.screenshot, Self.wide] {
-            let l = layout(rows)
-            for row in rows {
-                // Trailing alignment inside a column as wide as its widest
-                // cell: every row's number ends at the column's x, and no
-                // cell has to be squeezed to get there.
-                #expect(width(row.tokens) <= l.tokensColumnRight - l.tokensColumnLeft)
-                #expect(width(row.cost) <= l.costColumnRight - l.costColumnLeft)
+            print("#89 \(label) — per-row x (tokens right, cost left):")
+            for (i, row) in rows.enumerated() {
+                print(line("  " + row.name, old.tokensRight[i], old.costLeft[i],
+                           new.tokensRight[i], new.costLeft[i]))
             }
-        }
+            print(line("  spread old/new",
+                       spread(old.tokensRight), spread(old.costLeft),
+                       spread(new.tokensRight), spread(new.costLeft)))
 
-        let l = layout(Self.screenshot)
-        print("#89 new layout — one x per column, every row:")
-        print(line("tokens L/R", l.tokensColumnLeft, l.tokensColumnRight))
-        print(line("cost L/R", l.costColumnLeft, l.costColumnRight))
-        print(line("spread", 0, 0))
+            // Measured at 14.33 pt in the issue. Loose lower bound so a font
+            // metric change cannot fail the documentation half of this.
+            #expect(spread(old.tokensRight) > 5, "the wander this issue is about")
+            #expect(spread(old.costLeft) > 5)
+            #expect(spread(new.tokensRight) == 0)
+            #expect(spread(new.costLeft) == 0)
+
+            // And the columns have to actually fit to reach those x — this is
+            // the half that can regress.
+            let l = layout(rows)
+            #expect(l.tokensColumnLeft > 0)
+            #expect(l.labelAvailable > 0)
+        }
     }
+
+    // MARK: - Width budget
 
     @Test func columnsFitTheTooltipAtTodaysWidth() {
         let l = layout(Self.screenshot)
-        let widest = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
+        let widestInScreenshot = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
+        let widestPossible = labelCellWidth(Self.widestClientName)
 
-        print(line("#89 screenshot", widest, l.labelAvailable))
+        print(line("#89 screenshot", l.labelAvailable, widestInScreenshot, widestPossible))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
-        #expect(l.labelAvailable > widest,
+        #expect(l.labelAvailable > widestInScreenshot,
                 "the screenshot's rows must fit without truncating a client name")
+        #expect(l.labelAvailable > widestPossible,
+                "so must the widest name ClientRegistry can produce")
     }
 
-    /// The wide case: a 12-digit token count next to a 3-digit cost still
-    /// leaves the label cell its dot and a readable name. Rows wider than
-    /// that truncate the name — the numbers never move.
+    /// The wide case: a 12-digit token count next to a 3-digit cost. Here the
+    /// numbers deliberately win — `"Grok Build"` does not fit beside them and
+    /// truncates, which is this PR's chosen failure mode. What must still
+    /// hold is that both number columns fit and the label keeps its dot and a
+    /// short name.
     @Test func wideCaseStillFitsBothNumberColumns() {
         let l = layout(Self.wide)
-        let shortestPlausibleLabel = labelCellWidth("Amp")
 
-        print(line("#89 wide", shortestPlausibleLabel, l.labelAvailable))
+        print(line("#89 wide", l.labelAvailable,
+                   labelCellWidth("Amp"), labelCellWidth(Self.widestClientName)))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
-        #expect(l.labelAvailable > shortestPlausibleLabel)
+        #expect(l.labelAvailable > labelCellWidth("Amp"),
+                "the shortest client name must survive even the widest numbers")
     }
 
     @Test func metricsMatchTheTooltipBox() {

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -62,9 +62,12 @@ import Testing
 
     /// The widest label the tooltip can draw, taken from `ClientRegistry` so
     /// that adding a client re-budgets this suite instead of quietly
-    /// outgrowing a name written down here. `ClientStyle.shortName` strips
-    /// only `" CLI" / " Code" / " IDE"`, so `grok`'s "Grok Build" survives
-    /// whole and beats "Synthetic", "OpenClaw", "OpenCode" and "Oh My Pi".
+    /// outgrowing a name written down here — and by measured width, not by
+    /// character count: `ClientStyle.shortName` strips only `" CLI" / " Code"
+    /// / " IDE"`, which leaves `grok`'s "Grok Build" the longest name at ten
+    /// characters, but "OpenCode" is the wider one at 10 pt medium (52.13 pt
+    /// of text, measured on macOS 15) because its round glyphs beat the
+    /// narrow `r k i l d` and the space. The tests print whichever it is.
     private var widestClientName: String {
         ClientRegistry.allIDs
             .map { ClientRegistry.style(for: $0).shortName }
@@ -138,7 +141,9 @@ import Testing
                 "the screenshot's rows must fit without truncating a client name")
         // Not a name in the screenshot but the widest one the registry can
         // produce: the fix changed what happens when a row does not fit, so
-        // the margin on the real worst case is worth locking down.
+        // the margin on the real worst case is worth locking down. It failed
+        // here at `columnSpacing` 6 — 62.83 available against 63.13 wanted —
+        // and that 0.30 pt is why the constant is 5, which leaves 1.70 pt.
         #expect(l.labelAvailable > widestPossible,
                 "so must the widest name ClientRegistry can produce")
     }

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -51,29 +51,14 @@ import Testing
     // MARK: - Measurement
 
     private func width(_ string: String, weight: NSFont.Weight = .regular) -> CGFloat {
-        let font = NSFont.systemFont(ofSize: TooltipMetrics.segmentFontSize, weight: weight)
-        return (string as NSString).size(withAttributes: [.font: font]).width
+        TooltipTestSupport.width(string, weight: weight)
     }
 
-    /// Width the dot + client name cell wants before any truncation.
     private func labelCellWidth(_ name: String) -> CGFloat {
-        TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing + width(name, weight: .medium)
+        TooltipTestSupport.labelCellWidth(name)
     }
 
-    /// The widest label the tooltip can draw, taken from `ClientRegistry` so
-    /// that adding a client re-budgets this suite instead of quietly
-    /// outgrowing a name written down here.
-    ///
-    /// Widest is measured, not counted: it is "OpenCode" at 52.13 pt, ahead of
-    /// the two characters longer "Grok Build". Round capitals beat a name with
-    /// a space and an `l` and an `i` in it. Both earlier passes at this test
-    /// reasoned from character count and named the wrong one, which is the
-    /// argument for deriving it here. The tests print whichever it is.
-    private var widestClientName: String {
-        ClientRegistry.allIDs
-            .map { ClientRegistry.style(for: $0).shortName }
-            .max { width($0, weight: .medium) < width($1, weight: .medium) } ?? ""
-    }
+    private var widestClientName: String { TooltipTestSupport.widestClientName }
 
     private func spread(_ xs: [CGFloat]) -> CGFloat { (xs.max() ?? 0) - (xs.min() ?? 0) }
 
@@ -134,27 +119,25 @@ import Testing
         let widestInScreenshot = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
         let widestPossible = labelCellWidth(widestClientName)
 
-        let overflow = widestPossible - l.labelAvailable
-
         print("#89 screenshot — label available, screenshot's widest, \(widestClientName)")
         print(line("  budget", l.labelAvailable, widestInScreenshot, widestPossible))
-        print(line("  overflow", overflow))
+        print(line("  margin", l.labelAvailable - widestPossible))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
         #expect(l.labelAvailable > widestInScreenshot,
                 "the screenshot's rows must fit without truncating a client name")
-        // The widest name the registry can produce does *not* fit these
-        // columns: "OpenCode" runs 0.30 pt over 62.83 pt and loses its last
-        // pixels to the ellipsis. That is the failure mode this PR chose —
-        // name gives, numbers hold — so it is recorded, not treated as a bug.
-        // An earlier revision asserted the opposite from an estimate, went red
-        // on CI, and was then "fixed" by narrowing the gutter to 5 pt: that
-        // moved a layout the owner had already rendered and measured, to
-        // satisfy an assertion nobody asked for. The gutter is 6 pt again and
-        // the bound here is one glyph, so a future client name that overflows
-        // by a visible amount still fails.
-        #expect(overflow < width("n", weight: .medium),
-                "the widest client name may truncate here, but only by a hair")
+        // Every name the registry can draw fits the screenshot's columns at
+        // full length — no ellipsis in the tooltip's ordinary case. Two things
+        // had to be true for this to hold, and neither on its own was enough:
+        // the label cell no longer pays for a trailing `Spacer`'s `HStack` gap
+        // (5 pt of the 5.4 pt shortfall), and `columnSpacing` is 5 rather than
+        // 6 (the other 2 pt, giving 1.70 pt of margin).
+        //
+        // This is the modelled half, kept because it prints the arithmetic and
+        // says which term moved. The claim itself belongs to the bitmap:
+        // `TooltipRenderMeasurementTests.widestClientNameRendersUntruncated`.
+        #expect(l.labelAvailable > widestPossible,
+                "\(widestClientName), the widest name the registry can draw, must not truncate")
     }
 
     /// The wide case: a 12-digit token count next to a 3-digit cost. Here the

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -1,5 +1,5 @@
 import AppKit
-import XCTest
+import Testing
 
 @testable import UserInterface
 
@@ -12,7 +12,7 @@ import XCTest
 /// column's alignment, so `Layout` below — column width = max over rows,
 /// trailing-aligned, packed against the content box's right edge — is the
 /// arrangement the view asks for. The alignment then comes for free; what
-/// this test measures with real font metrics is the part that does not:
+/// this suite measures with real font metrics is the part that does not:
 /// whether three columns and two gaps still fit the 174 pt content box at
 /// today's 190 pt tooltip width, for the screenshot's rows and for a
 /// deliberately wide one. The running app is the check that `Grid` renders
@@ -22,7 +22,7 @@ import XCTest
 /// measurements in the issue were produced. Two places sum substring widths,
 /// which ignores kerning across the join — good to a fraction of a point,
 /// which is the resolution this budget needs.
-final class TooltipColumnLayoutTests: XCTestCase {
+@Suite struct TooltipColumnLayoutTests {
     private struct Row {
         let name: String
         let tokens: String
@@ -60,8 +60,9 @@ final class TooltipColumnLayoutTests: XCTestCase {
     /// The Grid arrangement, resolved for a set of rows. All x are measured
     /// from the left edge of the tooltip's content box.
     private struct Layout {
-        let tokensColumnRight: CGFloat
         let tokensColumnLeft: CGFloat
+        let tokensColumnRight: CGFloat
+        let costColumnLeft: CGFloat
         let costColumnRight: CGFloat
         /// What is left for the dot + client name cell.
         let labelAvailable: CGFloat
@@ -73,26 +74,28 @@ final class TooltipColumnLayoutTests: XCTestCase {
         let costRight = TooltipMetrics.contentWidth
         let tokensRight = costRight - costColumn - TooltipMetrics.columnSpacing
         let tokensLeft = tokensRight - tokensColumn
-        return Layout(tokensColumnRight: tokensRight,
-                      tokensColumnLeft: tokensLeft,
+        return Layout(tokensColumnLeft: tokensLeft,
+                      tokensColumnRight: tokensRight,
+                      costColumnLeft: costRight - costColumn,
                       costColumnRight: costRight,
                       labelAvailable: tokensLeft - TooltipMetrics.columnSpacing)
     }
 
     private func line(_ label: String, _ values: CGFloat...) -> String {
-        let padded = label.padding(toLength: max(12, label.count), withPad: " ", startingAt: 0)
-        return padded + values.map { String(format: "%8.2f", Double($0)) }.joined()
+        label.padding(toLength: max(14, label.count), withPad: " ", startingAt: 0)
+            + values.map { String(format: "%8.2f", Double($0)) }.joined()
     }
 
     // MARK: - The bug
 
     /// Documents the cause: with one string per row, the x of both numbers is
     /// a function of that row's cost width alone.
-    func testSingleStringRowsPutEveryNumberAtADifferentX() {
+    @Test func singleStringRowsPutEveryNumberAtADifferentX() {
         var tokensRight: [CGFloat] = []
         var costLeft: [CGFloat] = []
 
-        print("old layout — one right-aligned string per row (tokens right, cost left):")
+        print("#89 old layout — one right-aligned string per row")
+        print("                tokens R  cost L")
         for row in Self.screenshot {
             let right = TooltipMetrics.contentWidth - width(" · " + row.cost)
             let left = TooltipMetrics.contentWidth - width(row.cost)
@@ -107,59 +110,57 @@ final class TooltipColumnLayoutTests: XCTestCase {
 
         // Measured at 14.33 pt in the issue. Asserted loosely so a future
         // font-metric change cannot fail this bit of documentation.
-        XCTAssertGreaterThan(tokensSpread, 5, "the wander this issue is about")
-        XCTAssertGreaterThan(costSpread, 5)
+        #expect(tokensSpread > 5, "the wander this issue is about")
+        #expect(costSpread > 5)
     }
 
     // MARK: - The fix
 
-    func testColumnLayoutGivesEveryRowTheSameX() {
+    @Test func columnLayoutGivesEveryRowTheSameX() {
         for rows in [Self.screenshot, Self.wide] {
             let l = layout(rows)
             for row in rows {
-                // Trailing alignment inside a column that is as wide as its
-                // widest cell: every row's number ends at the column's x, and
-                // no cell has to be squeezed to get there.
-                XCTAssertLessThanOrEqual(width(row.tokens),
-                                         l.tokensColumnRight - l.tokensColumnLeft)
-                XCTAssertLessThanOrEqual(width(row.cost),
-                                         TooltipMetrics.contentWidth - l.tokensColumnRight
-                                             - TooltipMetrics.columnSpacing)
+                // Trailing alignment inside a column as wide as its widest
+                // cell: every row's number ends at the column's x, and no
+                // cell has to be squeezed to get there.
+                #expect(width(row.tokens) <= l.tokensColumnRight - l.tokensColumnLeft)
+                #expect(width(row.cost) <= l.costColumnRight - l.costColumnLeft)
             }
         }
 
         let l = layout(Self.screenshot)
-        print("new layout — columns (same x for every row):")
-        print(line("tokens", l.tokensColumnLeft, l.tokensColumnRight))
-        print(line("cost", l.costColumnRight))
+        print("#89 new layout — one x per column, every row:")
+        print(line("tokens L/R", l.tokensColumnLeft, l.tokensColumnRight))
+        print(line("cost L/R", l.costColumnLeft, l.costColumnRight))
+        print(line("spread", 0, 0))
     }
 
-    func testColumnsFitTheTooltipAtTodaysWidth() {
+    @Test func columnsFitTheTooltipAtTodaysWidth() {
         let l = layout(Self.screenshot)
         let widest = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
 
-        print(line("screenshot", widest, l.labelAvailable))
-        XCTAssertGreaterThan(l.tokensColumnLeft, 0,
-                             "both number columns must fit the 174 pt content box")
-        XCTAssertGreaterThan(l.labelAvailable, widest,
-                             "the screenshot's rows must fit without truncating a client name")
+        print(line("#89 screenshot", widest, l.labelAvailable))
+        #expect(l.tokensColumnLeft > 0,
+                "both number columns must fit the 174 pt content box")
+        #expect(l.labelAvailable > widest,
+                "the screenshot's rows must fit without truncating a client name")
     }
 
     /// The wide case: a 12-digit token count next to a 3-digit cost still
     /// leaves the label cell its dot and a readable name. Rows wider than
     /// that truncate the name — the numbers never move.
-    func testWideCaseStillFitsBothNumberColumns() {
+    @Test func wideCaseStillFitsBothNumberColumns() {
         let l = layout(Self.wide)
         let shortestPlausibleLabel = labelCellWidth("Amp")
 
-        print(line("wide", shortestPlausibleLabel, l.labelAvailable))
-        XCTAssertGreaterThan(l.tokensColumnLeft, 0,
-                             "both number columns must fit the 174 pt content box")
-        XCTAssertGreaterThan(l.labelAvailable, shortestPlausibleLabel)
+        print(line("#89 wide", shortestPlausibleLabel, l.labelAvailable))
+        #expect(l.tokensColumnLeft > 0,
+                "both number columns must fit the 174 pt content box")
+        #expect(l.labelAvailable > shortestPlausibleLabel)
     }
 
-    func testMetricsMatchTheTooltipBox() {
-        XCTAssertEqual(TooltipMetrics.width, 190)
-        XCTAssertEqual(TooltipMetrics.contentWidth, 174)
+    @Test func metricsMatchTheTooltipBox() {
+        #expect(TooltipMetrics.width == 190)
+        #expect(TooltipMetrics.contentWidth == 174)
     }
 }

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -134,25 +134,27 @@ import Testing
         let widestInScreenshot = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
         let widestPossible = labelCellWidth(widestClientName)
 
-        let margin = l.labelAvailable - widestPossible
+        let overflow = widestPossible - l.labelAvailable
 
         print("#89 screenshot — label available, screenshot's widest, \(widestClientName)")
         print(line("  budget", l.labelAvailable, widestInScreenshot, widestPossible))
-        print(line("  margin", margin))
+        print(line("  overflow", overflow))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
         #expect(l.labelAvailable > widestInScreenshot,
                 "the screenshot's rows must fit without truncating a client name")
-        // Not a name in the screenshot but the widest one the registry can
-        // produce, and the one the tooltip must not have to truncate on
-        // ordinary numbers. It went red here at `columnSpacing` 6 — 62.83 pt
-        // available against the 63.13 pt "OpenCode" wants — and the layout
-        // moved to meet the assertion rather than the other way round: the
-        // gutter is 5 pt now, which leaves 1.70 pt. Truncation belongs to the
-        // wide case below, where the numbers genuinely need the room; a
-        // tolerance here would stop distinguishing the two.
-        #expect(l.labelAvailable > widestPossible,
-                "so must the widest name ClientRegistry can produce")
+        // The widest name the registry can produce does *not* fit these
+        // columns: "OpenCode" runs 0.30 pt over 62.83 pt and loses its last
+        // pixels to the ellipsis. That is the failure mode this PR chose —
+        // name gives, numbers hold — so it is recorded, not treated as a bug.
+        // An earlier revision asserted the opposite from an estimate, went red
+        // on CI, and was then "fixed" by narrowing the gutter to 5 pt: that
+        // moved a layout the owner had already rendered and measured, to
+        // satisfy an assertion nobody asked for. The gutter is 6 pt again and
+        // the bound here is one glyph, so a future client name that overflows
+        // by a visible amount still fails.
+        #expect(overflow < width("n", weight: .medium),
+                "the widest client name may truncate here, but only by a hair")
     }
 
     /// The wide case: a 12-digit token count next to a 3-digit cost. Here the

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -11,12 +11,15 @@ import Testing
 /// column the width of its widest cell and places every cell in it with the
 /// column's alignment, so `Layout` below — column width = max over rows,
 /// trailing-aligned, packed against the content box's right edge — is the
-/// arrangement the view asks for. The alignment then comes for free; what
-/// this suite measures with real font metrics is the part that does not:
-/// whether three columns and two gaps still fit the 174 pt content box at
-/// today's 190 pt tooltip width, for the screenshot's rows and for a
-/// deliberately wide one. The running app is the check that `Grid` renders
-/// this arrangement (verification 2 in the PR).
+/// arrangement the view asks for.
+///
+/// This suite is the *width budget* only: whether three columns and two gaps
+/// still fit the 174 pt content box at today's 190 pt tooltip width, for the
+/// screenshot's rows and for a deliberately wide one, and which client names
+/// survive that at full length. Asserting from `Layout` that the columns line
+/// up would be circular — that claim is `Grid`'s to keep, and
+/// `TooltipRenderMeasurementTests` checks it by rendering the real view and
+/// measuring the ink.
 ///
 /// Widths come from `NSAttributedString.size(withAttributes:)`, the way the
 /// measurements in the issue were produced. Two places sum substring widths,
@@ -38,12 +41,14 @@ import Testing
     ]
 
     /// A 12-digit token count against a 3-digit cost, per the issue's ask to
-    /// verify a wide case rather than only the screenshot's numbers. The name
-    /// is the longest one in `ClientRegistry`.
-    private static let wide = [
-        Row(name: "Synthetic", tokens: "999,999,999,999", cost: "$152.46"),
-        Row(name: "Codex", tokens: "4,092,946", cost: "$1.18"),
-    ]
+    /// verify a wide case rather than only the screenshot's numbers, carrying
+    /// the widest name the tooltip can draw.
+    private var wide: [Row] {
+        [
+            Row(name: widestClientName, tokens: "999,999,999,999", cost: "$152.46"),
+            Row(name: "Codex", tokens: "4,092,946", cost: "$1.18"),
+        ]
+    }
 
     // MARK: - Measurement
 
@@ -55,6 +60,17 @@ import Testing
     /// Width the dot + client name cell wants before any truncation.
     private func labelCellWidth(_ name: String) -> CGFloat {
         TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing + width(name, weight: .medium)
+    }
+
+    /// The widest label the tooltip can actually draw, derived from
+    /// `ClientRegistry` so adding a client re-budgets this suite instead of
+    /// silently outgrowing a hard-coded name. `shortName` strips only
+    /// " CLI"/" Code"/" IDE", so today this is "Grok Build" — wider than
+    /// "Synthetic", and wider than the longest *display* name.
+    private var widestClientName: String {
+        ClientRegistry.allIDs
+            .map { ClientRegistry.style(for: $0).shortName }
+            .max { width($0, weight: .medium) < width($1, weight: .medium) } ?? ""
     }
 
     /// The Grid arrangement, resolved for a set of rows. All x are measured
@@ -114,49 +130,46 @@ import Testing
         #expect(costSpread > 5)
     }
 
-    // MARK: - The fix
-
-    @Test func columnLayoutGivesEveryRowTheSameX() {
-        for rows in [Self.screenshot, Self.wide] {
-            let l = layout(rows)
-            for row in rows {
-                // Trailing alignment inside a column as wide as its widest
-                // cell: every row's number ends at the column's x, and no
-                // cell has to be squeezed to get there.
-                #expect(width(row.tokens) <= l.tokensColumnRight - l.tokensColumnLeft)
-                #expect(width(row.cost) <= l.costColumnRight - l.costColumnLeft)
-            }
-        }
-
-        let l = layout(Self.screenshot)
-        print("#89 new layout — one x per column, every row:")
-        print(line("tokens L/R", l.tokensColumnLeft, l.tokensColumnRight))
-        print(line("cost L/R", l.costColumnLeft, l.costColumnRight))
-        print(line("spread", 0, 0))
-    }
+    // MARK: - The width budget
 
     @Test func columnsFitTheTooltipAtTodaysWidth() {
         let l = layout(Self.screenshot)
-        let widest = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
+        let widestInScreenshot = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
+        let widestInRegistry = labelCellWidth(widestClientName)
 
-        print(line("#89 screenshot", widest, l.labelAvailable))
+        print("#89 screenshot columns — available \(String(format: "%.2f", l.labelAvailable)) pt for the label")
+        print(line("screenshot", widestInScreenshot))
+        print(line(widestClientName, widestInRegistry))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
-        #expect(l.labelAvailable > widest,
+        #expect(l.labelAvailable > widestInScreenshot,
                 "the screenshot's rows must fit without truncating a client name")
+        // Not the screenshot's names but the registry's: this is what the fix
+        // changed the failure mode of, so it is worth locking the margin.
+        #expect(l.labelAvailable > widestInRegistry,
+                "the widest name ClientRegistry can draw (\(widestClientName)) must fit the screenshot's columns")
     }
 
-    /// The wide case: a 12-digit token count next to a 3-digit cost still
-    /// leaves the label cell its dot and a readable name. Rows wider than
-    /// that truncate the name — the numbers never move.
-    @Test func wideCaseStillFitsBothNumberColumns() {
-        let l = layout(Self.wide)
-        let shortestPlausibleLabel = labelCellWidth("Amp")
+    /// The wide case: a 12-digit token count next to a 3-digit cost. Both
+    /// number columns still fit, and what gives is the name — measured here
+    /// rather than assumed, because that is the trade the fix chose.
+    @Test func wideCaseKeepsTheNumbersAndTruncatesTheName() {
+        let l = layout(wide)
+        let widest = labelCellWidth(widestClientName)
+        let dotAndEllipsis = TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing
+            + width("…", weight: .medium)
 
-        print(line("#89 wide", shortestPlausibleLabel, l.labelAvailable))
+        print(line("#89 wide", widest, l.labelAvailable))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
-        #expect(l.labelAvailable > shortestPlausibleLabel)
+        #expect(l.labelAvailable > dotAndEllipsis,
+                "the label cell keeps its dot and at least an ellipsis")
+        // The numbers win: at this width the widest name cannot be drawn in
+        // full and truncates with `.truncationMode(.tail)`. If this ever
+        // fails, the tooltip grew wide enough to hold it — update the
+        // expectation, nothing is broken.
+        #expect(l.labelAvailable < widest,
+                "\(widestClientName) truncates in the wide case, by design")
     }
 
     @Test func metricsMatchTheTooltipBox() {

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipColumnLayoutTests.swift
@@ -62,9 +62,13 @@ import Testing
 
     /// The widest label the tooltip can draw, taken from `ClientRegistry` so
     /// that adding a client re-budgets this suite instead of quietly
-    /// outgrowing a name written down here. `ClientStyle.shortName` strips
-    /// only `" CLI" / " Code" / " IDE"`, so `grok`'s "Grok Build" survives
-    /// whole and beats "Synthetic", "OpenClaw", "OpenCode" and "Oh My Pi".
+    /// outgrowing a name written down here.
+    ///
+    /// Widest is measured, not counted: it is "OpenCode" at 52.13 pt, ahead of
+    /// the two characters longer "Grok Build". Round capitals beat a name with
+    /// a space and an `l` and an `i` in it. Both earlier passes at this test
+    /// reasoned from character count and named the wrong one, which is the
+    /// argument for deriving it here.
     private var widestClientName: String {
         ClientRegistry.allIDs
             .map { ClientRegistry.style(for: $0).shortName }
@@ -130,17 +134,24 @@ import Testing
         let widestInScreenshot = Self.screenshot.map { labelCellWidth($0.name) }.max() ?? 0
         let widestPossible = labelCellWidth(widestClientName)
 
+        let overflow = widestPossible - l.labelAvailable
+
         print("#89 screenshot — label available, screenshot's widest, \(widestClientName)")
         print(line("  budget", l.labelAvailable, widestInScreenshot, widestPossible))
+        print(line("  overflow", overflow))
         #expect(l.tokensColumnLeft > 0,
                 "both number columns must fit the 174 pt content box")
         #expect(l.labelAvailable > widestInScreenshot,
                 "the screenshot's rows must fit without truncating a client name")
-        // Not a name in the screenshot but the widest one the registry can
-        // produce: the fix changed what happens when a row does not fit, so
-        // the margin on the real worst case is worth locking down.
-        #expect(l.labelAvailable > widestPossible,
-                "so must the widest name ClientRegistry can produce")
+        // The widest name the registry can produce does *not* fit these
+        // columns: "OpenCode" runs 0.30 pt over 62.83 pt and truncates. That
+        // is the failure mode this PR chose (name gives, numbers hold), so it
+        // is recorded rather than treated as a bug — an earlier revision
+        // asserted the opposite from an estimate and went red on CI. The bound
+        // is one glyph, so a future client name that overflows by a visible
+        // amount still fails here.
+        #expect(overflow < width("n", weight: .medium),
+                "the widest client name may truncate here, but only by a hair")
     }
 
     /// The wide case: a 12-digit token count next to a 3-digit cost. Here the

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
@@ -16,7 +16,8 @@ import Testing
 /// bitmap, and the band's rightmost inked pixel is that row's right edge.
 ///
 /// Measured on macOS 15 for the screenshot's four rows, x relative to the
-/// 174 pt content box:
+/// 174 pt content box, at `columnSpacing` 6 — the value shipped before the
+/// label cell dropped its trailing `Spacer`:
 ///
 ///     cost   173.12 173.12 173.12 173.12   spread 0.000
 ///     tokens 127.12 127.62 127.75 127.88   spread 0.750
@@ -26,7 +27,17 @@ import Testing
 /// than one ending in `6`. The advances are aligned; the ink is ragged by
 /// under a point. The single-string layout this replaced wandered 14.33 pt
 /// (`TooltipColumnLayoutTests.singleStringRowsPutEveryNumberAtADifferentX`),
-/// so the budgets below are ~19x tighter than the bug.
+/// so the budgets below are ~19x tighter than the bug. At `columnSpacing` 5
+/// the cost column does not move — it is flush against the content box — and
+/// the tokens column moves 1 pt right, with both spreads unchanged, which is
+/// what says the point came out of the gutter and not out of the alignment.
+/// The tests print the current table on every run.
+///
+/// The suite also settles what happens to the client name, in both directions:
+/// at the screenshot's numbers even the widest name the registry can draw
+/// renders whole, and against a 12-digit token count it truncates. Both are
+/// measured by rendering the same cell twice — once in the tooltip's box, once
+/// unconstrained — and comparing the ink.
 ///
 /// The suite is tied to the shipping view, not to a copy of it:
 /// `TooltipSegmentRows` lives in `UsageBarChart.swift`, so reverting that file
@@ -48,6 +59,27 @@ import Testing
         TooltipSegmentRows.Row(id: "omp", name: "Oh My Pi",
                                tokens: "32,521,315", cost: "$21.24", color: .black),
     ]
+
+    /// The screenshot's columns, with its widest row renamed to the widest
+    /// name `ClientRegistry` can draw. Same token and cost strings, so the two
+    /// number columns are exactly as wide as in `screenshot` — this asks what
+    /// the tooltip's ordinary case does to its longest label, nothing else.
+    private static var widestName: [TooltipSegmentRows.Row] {
+        [TooltipSegmentRows.Row(id: "widest", name: TooltipTestSupport.widestClientName,
+                                tokens: "599,788,471", cost: "$152.46", color: .black)]
+            + screenshot.dropFirst()
+    }
+
+    /// A 12-digit token count against a 3-digit cost, carrying that same name.
+    /// Here the numbers take the room and the name is expected to give.
+    private static var wide: [TooltipSegmentRows.Row] {
+        [
+            TooltipSegmentRows.Row(id: "widest", name: TooltipTestSupport.widestClientName,
+                                   tokens: "999,999,999,999", cost: "$152.46", color: .black),
+            TooltipSegmentRows.Row(id: "codex", name: "Codex",
+                                   tokens: "4,092,946", cost: "$1.18", color: .black),
+        ]
+    }
 
     // MARK: - The measurements
 
@@ -73,11 +105,11 @@ import Testing
     }
 
     /// The other half of the fix: `Grid` hands the slack to the label cell —
-    /// the one that ends in `Spacer(minLength: 0)` — so the number columns sit
-    /// against the content box's right edge, where the total row's cost above
-    /// them already is. If the slack went to the number columns instead, the
-    /// columns would still agree with each other but the block would be
-    /// left-shifted with a gap on the right. Measured at 173.12 of 174.
+    /// the one whose name carries `.frame(maxWidth: .infinity)` — so the number
+    /// columns sit against the content box's right edge, where the total row's
+    /// cost above them already is. If the slack went to the number columns
+    /// instead, the columns would still agree with each other but the block
+    /// would be left-shifted with a gap on the right. Measured at 173.12 of 174.
     @MainActor
     @Test func costColumnSitsAgainstTheContentBoxRightEdge() throws {
         let full = try rightEdges(of: nil)
@@ -88,15 +120,81 @@ import Testing
                 "the rows must be flush right, not left-shifted with a gap")
     }
 
+    // MARK: - What happens to the client name
+
+    /// At the screenshot's numbers the tooltip draws every client name whole,
+    /// the widest one the registry can produce included.
+    ///
+    /// Asserted against the render rather than a width model: the same label
+    /// cell is rendered twice, once in the tooltip's 190 pt box and once
+    /// unconstrained, and the two ink right edges must agree. An ellipsis
+    /// costs the row real pixels, so a truncated name lands well short of its
+    /// unconstrained self — this fails on truncation, it does not merely bound
+    /// it. A model of the cell's width is what got this wrong twice: it left
+    /// out the `HStack` gap a trailing `Spacer` charged for, and said 0.30 pt
+    /// short where the render truncated outright.
+    @MainActor
+    @Test func widestClientNameRendersUntruncated() throws {
+        let name = TooltipTestSupport.widestClientName
+        let drawn = try rightEdges(of: .label, rows: Self.widestName)
+        let ideal = try rightEdges(of: .label, rows: Self.widestName, constrained: false)
+
+        print("#89 label cell — widest registry name is \(name)")
+        print(row("in box", drawn))
+        print(row("ideal", ideal))
+
+        try #require(drawn.count == ideal.count,
+                     "one ink band per row in both renders")
+        for (i, (drawn, ideal)) in zip(drawn, ideal).enumerated() {
+            #expect(abs(drawn - ideal) <= 0.3,
+                    "row \(i) is truncated: ink ends at \(fmt(drawn)) pt, whole it needs \(fmt(ideal)) pt")
+        }
+    }
+
+    /// The other case, so both are on the record: with a 12-digit token count
+    /// there is no room for that name and this PR's chosen failure mode kicks
+    /// in — the numbers hold their columns and the name takes the ellipsis.
+    /// Asserted, not merely permitted, so a future change that starts
+    /// truncating the ordinary case cannot pass by calling it expected.
+    @MainActor
+    @Test func wideNumbersTruncateTheWidestClientName() throws {
+        let drawn = try rightEdges(of: .label, rows: Self.wide)
+        let ideal = try rightEdges(of: .label, rows: Self.wide, constrained: false)
+
+        print("#89 label cell, 12-digit tokens — \(TooltipTestSupport.widestClientName)")
+        print(row("in box", drawn))
+        print(row("ideal", ideal))
+
+        let drawnWidest = try #require(drawn.first)
+        let idealWidest = try #require(ideal.first)
+        #expect(idealWidest - drawnWidest > 0.3,
+                "the widest name has to give way to 12 digits, by design")
+        // The short name in the second row still survives; if it stopped
+        // fitting, the tooltip would be drawing rows with no identity at all.
+        if drawn.count > 1, ideal.count > 1 {
+            #expect(abs(drawn[1] - ideal[1]) <= 0.3,
+                    "a short client name must survive even the widest numbers")
+        }
+    }
+
     // MARK: - Rendering and pixel measurement
 
     /// Right edge of every ink band, in points from the content box's left
     /// edge, for a render showing only `column` (all three when `nil`).
+    ///
+    /// `constrained: false` renders the same rows at their ideal size instead
+    /// of in the tooltip's 190 pt box, which is how a cell's drawn ink is
+    /// compared against the ink it wants. Both renders keep the same padding,
+    /// so both x's are relative to the same content-box left edge.
     @MainActor
-    private func rightEdges(of column: TooltipSegmentRows.Column?) throws -> [CGFloat] {
-        let content = TooltipSegmentRows(rows: Self.screenshot, inkedColumn: column)
+    private func rightEdges(of column: TooltipSegmentRows.Column?,
+                            rows: [TooltipSegmentRows.Row] = TooltipRenderMeasurementTests.screenshot,
+                            constrained: Bool = true) throws -> [CGFloat] {
+        let box = TooltipSegmentRows(rows: rows, inkedColumn: column)
             .padding(TooltipMetrics.padding)
-            .frame(width: TooltipMetrics.width)
+        let content = constrained
+            ? AnyView(box.frame(width: TooltipMetrics.width))
+            : AnyView(box.fixedSize())
         let renderer = ImageRenderer(content: content)
         renderer.scale = Self.scale
         let image = try #require(renderer.cgImage, "ImageRenderer produced no bitmap")

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
@@ -72,11 +72,17 @@ import Testing
 
     /// A 12-digit token count against a 3-digit cost, carrying that same name.
     /// Here the numbers take the room and the name is expected to give.
+    ///
+    /// The second row is "Amp", the *shortest* name the registry can draw, on
+    /// purpose: 12 digits leave the label cell about 40 pt, and a mid-length
+    /// name like "Codex" lands close enough to that to be a coin toss. The
+    /// floor worth asserting is the one the width budget already uses — the
+    /// shortest name plus its dot survives even the widest numbers.
     private static var wide: [TooltipSegmentRows.Row] {
         [
             TooltipSegmentRows.Row(id: "widest", name: TooltipTestSupport.widestClientName,
                                    tokens: "999,999,999,999", cost: "$152.46", color: .black),
-            TooltipSegmentRows.Row(id: "codex", name: "Codex",
+            TooltipSegmentRows.Row(id: "amp", name: "Amp",
                                    tokens: "4,092,946", cost: "$1.18", color: .black),
         ]
     }
@@ -145,9 +151,9 @@ import Testing
 
         try #require(drawn.count == ideal.count,
                      "one ink band per row in both renders")
-        for (i, (drawn, ideal)) in zip(drawn, ideal).enumerated() {
-            #expect(abs(drawn - ideal) <= 0.3,
-                    "row \(i) is truncated: ink ends at \(fmt(drawn)) pt, whole it needs \(fmt(ideal)) pt")
+        for (i, pair) in zip(drawn, ideal).enumerated() {
+            #expect(abs(pair.0 - pair.1) <= 0.3,
+                    "row \(i) is truncated: ink ends at \(fmt(pair.0)) pt, whole it needs \(fmt(pair.1)) pt")
         }
     }
 
@@ -161,7 +167,7 @@ import Testing
         let drawn = try rightEdges(of: .label, rows: Self.wide)
         let ideal = try rightEdges(of: .label, rows: Self.wide, constrained: false)
 
-        print("#89 label cell, 12-digit tokens — \(TooltipTestSupport.widestClientName)")
+        print("#89 label cell, 12-digit tokens — \(TooltipTestSupport.widestClientName), then Amp")
         print(row("in box", drawn))
         print(row("ideal", ideal))
 

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
@@ -1,0 +1,182 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import UserInterface
+
+/// Issue #89, the check that can actually fail: render `TooltipSegmentRows` —
+/// the view the tooltip draws, not a copy of it — with `ImageRenderer` and
+/// read each column's right edge off the bitmap.
+///
+/// Method (the owner's, reproduced): render the rows at scale 8 inside the
+/// tooltip's own box (`.padding(8).frame(width: 190)`), once per column with
+/// the other two at `.opacity(0)` so each column's ink is unambiguous —
+/// opacity changes no cell's size, so the columns measured are the ones the
+/// app lays out. Every row then occupies its own horizontal band of the
+/// bitmap, and the band's rightmost inked pixel is that row's right edge.
+///
+/// Measured on macOS 15 for the screenshot's four rows, x relative to the
+/// 174 pt content box:
+///
+///     cost   173.12 173.12 173.12 173.12   spread 0.000
+///     tokens 127.12 127.62 127.75 127.88   spread 0.750
+///
+/// The 0.75 pt on the tokens column is not misalignment: SF's digits are
+/// proportional, so a number ending in `1` leaves more right side bearing
+/// than one ending in `6`. The advances are aligned; the ink is ragged by
+/// under a point. The single-string layout this replaced wandered 14.33 pt
+/// (`TooltipColumnLayoutTests.singleStringRowsPutEveryNumberAtADifferentX`),
+/// so the budgets below are ~19x tighter than the bug.
+///
+/// The suite is tied to the shipping view, not to a copy of it:
+/// `TooltipSegmentRows` lives in `UsageBarChart.swift`, so reverting that file
+/// takes the type with it and this stops compiling; putting the old
+/// one-string-per-row layout back while keeping the type re-introduces the
+/// wander and blows the budgets.
+@Suite struct TooltipRenderMeasurementTests {
+    /// 8x, so one pixel is 0.125 pt — an order finer than the budgets.
+    private static let scale: CGFloat = 8
+
+    /// The four rows in the issue's screenshot (Sep 5).
+    private static let screenshot = [
+        TooltipSegmentRows.Row(id: "aside", name: "Aside",
+                               tokens: "599,788,471", cost: "$152.46", color: .black),
+        TooltipSegmentRows.Row(id: "claude", name: "Claude",
+                               tokens: "8,481,070", cost: "$20.22", color: .black),
+        TooltipSegmentRows.Row(id: "codex", name: "Codex",
+                               tokens: "4,092,946", cost: "$1.18", color: .black),
+        TooltipSegmentRows.Row(id: "omp", name: "Oh My Pi",
+                               tokens: "32,521,315", cost: "$21.24", color: .black),
+    ]
+
+    // MARK: - The measurements
+
+    @MainActor
+    @Test func renderedNumberColumnsShareOneRightEdge() throws {
+        let tokens = try rightEdges(of: .tokens)
+        let cost = try rightEdges(of: .cost)
+
+        print("#89 rendered at \(Int(Self.scale))x, x from the content box's left edge")
+        print(row("tokens", tokens))
+        print(row("cost", cost))
+
+        #expect(tokens.count == Self.screenshot.count,
+                "expected one ink band per row in the tokens column, got \(tokens.count)")
+        #expect(cost.count == Self.screenshot.count,
+                "expected one ink band per row in the cost column, got \(cost.count)")
+
+        // 14.33 pt of wander before the fix. What is left is side bearing.
+        #expect(spread(tokens) <= 1.0,
+                "tokens column spread \(fmt(spread(tokens))) pt")
+        #expect(spread(cost) <= 0.3,
+                "cost column spread \(fmt(spread(cost))) pt")
+    }
+
+    /// The other half of the fix: `Grid` hands the slack to the label cell —
+    /// the one that ends in `Spacer(minLength: 0)` — so the number columns sit
+    /// against the content box's right edge, where the total row's cost above
+    /// them already is. If the slack went to the number columns instead, the
+    /// columns would still agree with each other but the block would be
+    /// left-shifted with a gap on the right. Measured at 173.12 of 174.
+    @MainActor
+    @Test func costColumnSitsAgainstTheContentBoxRightEdge() throws {
+        let full = try rightEdges(of: nil)
+        let right = try #require(full.max())
+
+        print("#89 full render — ink right edge \(fmt(right)) of \(fmt(TooltipMetrics.contentWidth)) pt")
+        #expect(TooltipMetrics.contentWidth - right <= 1.5,
+                "the rows must be flush right, not left-shifted with a gap")
+    }
+
+    // MARK: - Rendering and pixel measurement
+
+    /// Right edge of every ink band, in points from the content box's left
+    /// edge, for a render showing only `column` (all three when `nil`).
+    @MainActor
+    private func rightEdges(of column: TooltipSegmentRows.Column?) throws -> [CGFloat] {
+        let content = TooltipSegmentRows(rows: Self.screenshot, inkedColumn: column)
+            .padding(TooltipMetrics.padding)
+            .frame(width: TooltipMetrics.width)
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = Self.scale
+        let image = try #require(renderer.cgImage, "ImageRenderer produced no bitmap")
+        return Self.inkBandRightEdges(image)
+    }
+
+    /// Scans the bitmap top to bottom for bands of inked pixel rows and
+    /// returns each band's rightmost ink, converted to points relative to the
+    /// content box. With one column showing, a band is exactly one row.
+    private static func inkBandRightEdges(_ image: CGImage) -> [CGFloat] {
+        let w = image.width, h = image.height
+        guard w > 0, h > 0 else { return [] }
+        var pixels = [UInt8](repeating: 0, count: w * h * 4)
+        let drawn = pixels.withUnsafeMutableBytes { buffer -> Bool in
+            guard let base = buffer.baseAddress,
+                  let context = CGContext(
+                      data: base, width: w, height: h,
+                      bitsPerComponent: 8, bytesPerRow: w * 4,
+                      space: CGColorSpaceCreateDeviceRGB(),
+                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+            else { return false }
+            context.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+            return true
+        }
+        guard drawn else { return [] }
+
+        // Alpha over ~12 %: past the antialiasing haze at a glyph's edge.
+        // Every column is read with the same threshold, so whatever it shaves
+        // off one row's edge it shaves off all of them — and these tests
+        // compare rows of one column against each other.
+        let threshold: UInt8 = 32
+        var edges: [CGFloat] = []
+        var bandRight: Int?
+
+        for y in 0..<h {
+            var rowRight: Int?
+            var x = w - 1
+            while x >= 0 {
+                if pixels[(y * w + x) * 4 + 3] >= threshold {
+                    rowRight = x
+                    break
+                }
+                x -= 1
+            }
+            switch (rowRight, bandRight) {
+            case let (right?, current):
+                bandRight = max(current ?? 0, right)
+            case (nil, let current?):
+                // Blank pixel row: the band ended.
+                edges.append(point(current))
+                bandRight = nil
+            case (nil, nil):
+                continue
+            }
+        }
+        if let bandRight {
+            edges.append(point(bandRight))
+        }
+        return edges
+    }
+
+    /// Far side of pixel column `x`, in points from the content box's left edge.
+    private static func point(_ x: Int) -> CGFloat {
+        CGFloat(x + 1) / scale - TooltipMetrics.padding
+    }
+
+    // MARK: - Reporting
+
+    private func spread(_ values: [CGFloat]) -> CGFloat {
+        guard let low = values.min(), let high = values.max() else { return 0 }
+        return high - low
+    }
+
+    private func fmt(_ value: CGFloat) -> String {
+        String(format: "%.2f", Double(value))
+    }
+
+    private func row(_ label: String, _ values: [CGFloat]) -> String {
+        label.padding(toLength: max(8, label.count), withPad: " ", startingAt: 0)
+            + values.map { String(format: "%8.2f", Double($0)) }.joined()
+            + "   spread " + fmt(spread(values))
+    }
+}

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
@@ -21,12 +21,6 @@ import Testing
 ///     cost   173.12 173.12 173.12 173.12   spread 0.000
 ///     tokens 127.12 127.62 127.75 127.88   spread 0.750
 ///
-/// Those x's were read with `TooltipMetrics.columnSpacing` at 6; it is 5 now
-/// (the widest client name did not fit the label cell at 6), so the tokens
-/// column sits one point further right — ~128.1 — while the cost column, which
-/// is flush against the content box, does not move. Both budgets below are on
-/// the spread within a column, so neither is affected; the run prints the x's.
-///
 /// The 0.75 pt on the tokens column is not misalignment: SF's digits are
 /// proportional, so a number ending in `1` leaves more right side bearing
 /// than one ending in `6`. The advances are aligned; the ink is ragged by

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipRenderMeasurementTests.swift
@@ -21,6 +21,12 @@ import Testing
 ///     cost   173.12 173.12 173.12 173.12   spread 0.000
 ///     tokens 127.12 127.62 127.75 127.88   spread 0.750
 ///
+/// Those x's were read with `TooltipMetrics.columnSpacing` at 6; it is 5 now
+/// (the widest client name did not fit the label cell at 6), so the tokens
+/// column sits one point further right — ~128.1 — while the cost column, which
+/// is flush against the content box, does not move. Both budgets below are on
+/// the spread within a column, so neither is affected; the run prints the x's.
+///
 /// The 0.75 pt on the tokens column is not misalignment: SF's digits are
 /// proportional, so a number ending in `1` leaves more right side bearing
 /// than one ending in `6`. The advances are aligned; the ink is ragged by

--- a/native/LocalPackage/Tests/UserInterfaceTests/TooltipTestSupport.swift
+++ b/native/LocalPackage/Tests/UserInterfaceTests/TooltipTestSupport.swift
@@ -1,0 +1,39 @@
+import AppKit
+
+@testable import UserInterface
+
+/// Shared by the tooltip's two suites so "the widest name the registry can
+/// draw" has exactly one definition. Both suites budget against it — one from
+/// AppKit metrics, one from the rendered bitmap — and a disagreement between
+/// them is a finding, not a fixture drift.
+enum TooltipTestSupport {
+    static func width(_ string: String, weight: NSFont.Weight = .regular) -> CGFloat {
+        let font = NSFont.systemFont(ofSize: TooltipMetrics.segmentFontSize, weight: weight)
+        return (string as NSString).size(withAttributes: [.font: font]).width
+    }
+
+    /// Width the dot + client name cell wants before any truncation: the dot,
+    /// the one `HStack` gap after it, and the name. There is no trailing gap —
+    /// the name itself is the cell's flexible element, so this is the whole
+    /// cell, which is the correction that made this budget agree with the
+    /// render (a trailing `Spacer` used to add a second 5 pt gap the model
+    /// never counted).
+    static func labelCellWidth(_ name: String) -> CGFloat {
+        TooltipMetrics.dotSize + TooltipMetrics.dotLabelSpacing + width(name, weight: .medium)
+    }
+
+    /// The widest label the tooltip can draw, taken from `ClientRegistry` so
+    /// that adding a client re-budgets both suites instead of quietly
+    /// outgrowing a name written down here.
+    ///
+    /// Widest is measured, not counted: "OpenCode" at 52.13 pt, ahead of the
+    /// two characters longer "Grok Build". Round capitals beat a name with a
+    /// space, an `l` and an `i` in it. Two earlier passes at this reasoned from
+    /// character count and named the wrong one, which is the argument for
+    /// deriving it. The tests print whichever it is.
+    static var widestClientName: String {
+        ClientRegistry.allIDs
+            .map { ClientRegistry.style(for: $0).shortName }
+            .max { width($0, weight: .medium) < width($1, weight: .medium) } ?? ""
+    }
+}


### PR DESCRIPTION
🤖 **Claude Code**

> Description refreshed at `af257ac` — the original text described the first round's layout and test names, both of which have since changed.

## Summary

The tooltip's per-client rows drew `"<tokens> · <cost>"` as one right-aligned `Text`, so the row's right edge was the only fixed x and both numbers slid left by however wide that row's cost happened to be — the 14.33 pt wander measured in #89.

The rows are now a three-column `Grid` (dot+name | tokens | cost). `Grid` sizes each column to its widest cell and trailing-aligns every cell in it, so both numbers read straight down. The label cell is the only horizontally flexible one — the client name carries `.frame(maxWidth: .infinity, alignment: .leading)` — so it absorbs the slack and the two number columns stay flush against the content box's right edge, where the total row's cost already sits. The total row is unchanged and its right edge now agrees with the cost column.

`Grid` over `.monospacedDigit()`, per the issue: neither was used in `native/` before, and monospaced digits alone would not have fixed this. No new `.monospacedDigit()` anywhere.

## Changes

- `native/LocalPackage/Sources/UserInterface/Views/UsageBarChart.swift`
  - Segment rows: `HStack` + `Spacer` → a `TooltipSegmentRows` view built from `Grid` / `GridRow`, three columns. It is a view of its own so the render test measures the rows the app draws rather than a copy of them, and it lives in this file so reverting the file takes the type — and the test target — with it.
  - The `·` is gone — aligned columns are the separation.
  - Number cells are `.fixedSize()` and no longer inherit the row's `.minimumScaleFactor(0.7)`; the client name takes `.lineLimit(1)` + `.truncationMode(.tail)` instead.
  - New file-scope `TooltipMetrics` (width 190, padding 8, column spacing 5, dot 6, dot↔label 5, segment font 10) replaces the literals in the view, including the `95` in the `.position` clamp, which was `width / 2`.
  - Total row and divider untouched.
- `native/LocalPackage/Tests/UserInterfaceTests/`, `Package.swift` — new `UserInterfaceTests` target: a render measurement, a width budget, and a shared fixture helper.

## The two numbers that pin the layout

`columnSpacing` is 5, not the 6 this PR opened with, and the label cell has no trailing `Spacer`. Both were needed and neither was enough alone:

- A trailing `Spacer(minLength: 0)` made the cell flexible, but `HStack(spacing: 5)` charges a gap *before* it too, so the cell's ideal width carried a phantom 5 pt. Making the name itself the flexible element gets the same behaviour for one gap instead of two.
- `columnSpacing` 6 → 5 then lifts the label cell's share from 62.83 pt to 64.83 pt, against 63.13 pt for the widest name `ClientRegistry` can draw.

Together: the widest client name renders whole at the screenshot's numbers, measured on the bitmap rather than modelled.

## Assumptions

- **What happens when a row genuinely doesn't fit**: the numbers win, the name truncates. `.minimumScaleFactor` on a cell lets that cell shrink its own text, which re-breaks the column it sits in — exactly the failure mode the issue warns about — so the number cells are `.fixedSize()` and the name gets the ellipsis. Nothing scales down any more. Both sides of that are asserted: whole at the screenshot's numbers, truncated against a 12-digit token count.
- The `·` is dropped rather than kept as a fourth column.
- The total row is left as-is (11 pt, `Spacer`-aligned). Its right edge coincides with the new cost column because both are flush right in the same 174 pt content box, without giving the 11 pt cost a say in the 10 pt column's width.

## How to verify

**1. Numbers, not eyeballing.** `swift test` prints every table below; these are the values from CI on `af257ac`, macos-15.

`TooltipRenderMeasurementTests` renders `TooltipSegmentRows` with `ImageRenderer(scale: 8)` inside `.padding(8).frame(width: 190)` and reads ink off the bitmap, one column at a time with the others at `.opacity(0)`:

- `renderedNumberColumnsShareOneRightEdge` — `tokens 128.25 128.75 128.75 128.88` (spread 0.62 ≤ 1.0), `cost 173.12 173.12 173.25 173.12` (spread 0.12 ≤ 0.3). The residual is SF's proportional digits leaving different right side bearing, not misalignment.
- `costColumnSitsAgainstTheContentBoxRightEdge` — full render ink right edge 173.25 of 174.00 pt, i.e. `Grid` hands the slack to the label cell rather than the number columns.
- `widestClientNameRendersUntruncated` — the label cell rendered in the box and unconstrained, ink identical to the pixel (`62.50 44.75 41.75 54.00` both ways). Fails on truncation, does not merely bound it.
- `wideNumbersTruncateTheWidestClientName` — with 12 digits, `in box 33.00` against `ideal 62.50`: the name gives way by design, while a short name is untouched.

`TooltipColumnLayoutTests` is the width budget from AppKit metrics — `singleStringRowsPutEveryNumberAtADifferentX` keeps the old layout's 14.33 pt as the contrast, and `columnsFitTheTooltipAtTodaysWidth` prints the label budget and its 1.70 pt margin. It deliberately does not assert alignment from its own model; that claim belongs to the bitmap.

**2. In the app** — `cd native && xcodegen generate && open Tokcat.xcodeproj`, hover a day with three or more clients whose costs differ in digit count (the Sep 5 day in the issue). Expected: tokens and cost each read straight down, the tooltip is still 190 pt, nothing clipped or scaled, and no client name showing an ellipsis.

**3. CI** — `swift build`, `swift test`, and the xcodegen app build, all green on `af257ac`. `Grid`/`GridRow`/`.gridColumnAlignment` and `ImageRenderer` are macOS 13.0, at the package's `.macOS(.v13)` floor.

## Risks / follow-ups

- First test target that links `UserInterface`, and the first that renders SwiftUI headlessly. `ImageRenderer` has now run green on macos-15 across several CI runs, so the earlier worry about headless rendering is settled.
- `ContributionGraph3D`'s hover card and the prose `·` in `AgentLimitsCard` / `UsageTraceCard` / `SettingsSheet` are untouched, as the issue scoped.
- The label budget is derived from `ClientRegistry`, so adding a client with a wider `shortName` re-budgets these tests rather than silently truncating in the tooltip. Today that name is `OpenCode`, with 1.70 pt of margin.

Closes #89

<!-- claude-harness kind=DISPATCH issue=89 -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q2hwx3BbDuymskHW65oS1