### PR TITLE
Release Tokcat 0.3.3

### DIFF
--- a/native/project.yml
+++ b/native/project.yml
@@ -29,8 +29,8 @@ targets:
         # bundle is Tokcat.app.
         EXECUTABLE_NAME: tokcat
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        MARKETING_VERSION: 0.3.2
-        CURRENT_PROJECT_VERSION: 12
+        MARKETING_VERSION: 0.3.3
+        CURRENT_PROJECT_VERSION: 13
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Manual
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
Bump MARKETING_VERSION 0.3.2 → 0.3.3 and CURRENT_PROJECT_VERSION 12 → 13 for the next release tag.