### PR TITLE
Keep a Cmd-dragged menu-bar slot across rebuilds and relaunches

### DIFF
--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
@@ -18,10 +18,6 @@ public final class StatusItemController: NSObject {
     private static let iconPointSize: CGFloat = 18
     private static let iconXOffset: CGFloat = 8
 
-    // Where macOS stores the item's spot, and the copy of the value we last
-    // wrote there ourselves (so a user drag is distinguishable from it).
-    private static let positionKey = "NSStatusItem Preferred Position Item-0"
-    private static let seededPositionKey = "TokcatSeededStatusItemPosition"
     private static let fallbackPosition = 200.0
 
     private var statusItem: NSStatusItem
@@ -33,7 +29,10 @@ public final class StatusItemController: NSObject {
     private var screenObserver: (any NSObjectProtocol)?
     private var hiddenChecks = 0
     private var lastRecoveryAt = Date.distantPast
-    private var preservedUserPosition = false
+    // Where macOS keeps the item's spot, and the user position the last rebuild
+    // left in place — cleared as soon as the item is seen on screen again.
+    private let positions = StatusItemPositionStore()
+    private var preservedPosition: Double?
 
     public var onLeftClick: (() -> Void)?
     public var menuProvider: (() -> NSMenu)?
@@ -41,7 +40,11 @@ public final class StatusItemController: NSObject {
     public var button: NSStatusBarButton? { statusItem.button }
 
     public override init() {
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // Before the first item exists: AppKit reads the position preference
+        // when it places the item, so a pre-autosaveName drag has to be on the
+        // autosave key by then or the user's slot is lost for this launch.
+        StatusItemPositionStore().migrateLegacyPositionIfNeeded()
+        statusItem = StatusItemController.makeStatusItem()
         super.init()
         configureItem()
         startVisibilityWatch()
@@ -54,6 +57,17 @@ public final class StatusItemController: NSObject {
                 MainActor.assumeIsolated { self?.logDiagnostics() }
             }
         }
+    }
+
+    // A stable autosaveName is what keys the position preference to a name we
+    // control: AppKit's generated "Item-N" is positional, and it does not
+    // reliably survive removeStatusItem() or quit, so a Cmd-drag could be lost
+    // on a plain relaunch and on every hidden-item rebuild.
+    private static func makeStatusItem() -> NSStatusItem {
+        let item = NSStatusBar.system.statusItem(
+            withLength: NSStatusItem.variableLength)
+        item.autosaveName = StatusItemPositionStore.autosaveName
+        return item
     }
 
     private func configureItem() {
@@ -79,8 +93,8 @@ public final class StatusItemController: NSObject {
 
     // MARK: - Hidden-item recovery
     //
-    // macOS persists each status item's preferred position ("NSStatusItem
-    // Preferred Position Item-0"). After a display-layout change (undocking
+    // macOS persists each status item's preferred position (see
+    // StatusItemPositionStore). After a display-layout change (undocking
     // a notched MacBook, narrower bar) that position can land inside the
     // app-menu zone or the notch — the item's window is then parked far
     // off-screen and macOS NEVER re-places it, even when space frees up,
@@ -125,6 +139,11 @@ public final class StatusItemController: NSObject {
     private func checkVisibility() {
         guard isEffectivelyHidden else {
             hiddenChecks = 0
+            // The item is reachable on the position it currently has, so that
+            // position is not the cause of any later hiding. Forgetting it here
+            // is what keeps an unrelated second rebuild — display sleep, a
+            // dock/undock round trip — from reseating a slot the user chose.
+            preservedPosition = nil
             return
         }
         hiddenChecks += 1
@@ -144,8 +163,7 @@ public final class StatusItemController: NSObject {
         runner.removeFromSuperlayer()
         NSStatusBar.system.removeStatusItem(statusItem)
         reseatPositionIfNeeded()
-        statusItem = NSStatusBar.system.statusItem(
-            withLength: NSStatusItem.variableLength)
+        statusItem = Self.makeStatusItem()
         configureItem()
     }
 
@@ -156,16 +174,16 @@ public final class StatusItemController: NSObject {
     // system items, in the always-visible region. See StatusItemPlacement for
     // when the stored position is left alone instead.
     private func reseatPositionIfNeeded() {
-        let defaults = UserDefaults.standard
+        // Read fresh: a drag performed between two rebuilds must re-arm the
+        // preserve branch rather than look like the position we already tried.
         let decision = StatusItemPlacement.decide(
-            stored: defaults.object(forKey: Self.positionKey) as? Double,
-            seeded: defaults.object(forKey: Self.seededPositionKey) as? Double,
-            alreadyPreserved: preservedUserPosition,
+            stored: positions.storedPosition,
+            seeded: positions.seededPosition,
+            preserved: preservedPosition,
             fallback: Self.fallbackPosition)
-        preservedUserPosition = decision.preservedUserPosition
+        preservedPosition = decision.preserve
         guard let seatAt = decision.seatAt else { return }
-        defaults.set(seatAt, forKey: Self.positionKey)
-        defaults.set(seatAt, forKey: Self.seededPositionKey)
+        positions.seat(at: seatAt)
     }
 
     private var diagTimer: Timer?

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemController.swift
@@ -60,9 +60,11 @@ public final class StatusItemController: NSObject {
     }
 
     // A stable autosaveName is what keys the position preference to a name we
-    // control: AppKit's generated "Item-N" is positional, and it does not
-    // reliably survive removeStatusItem() or quit, so a Cmd-drag could be lost
-    // on a plain relaunch and on every hidden-item rebuild.
+    // control, instead of AppKit's generated and positional "Item-N". Measured
+    // on macOS 26: with the name set, the status bar reads and writes
+    // "NSStatusItem Preferred Position TokcatStatusItem" and leaves the
+    // generated key untouched — including when it restores the slot on launch,
+    // even though the name can only be assigned after the item is created.
     private static func makeStatusItem() -> NSStatusItem {
         let item = NSStatusBar.system.statusItem(
             withLength: NSStatusItem.variableLength)
@@ -99,10 +101,11 @@ public final class StatusItemController: NSObject {
     // app-menu zone or the notch — the item's window is then parked far
     // off-screen and macOS NEVER re-places it, even when space frees up,
     // while `isVisible` keeps reporting true. Reproduced deterministically
-    // by seeding a large preferred position. A freshly created item with no
-    // stored position always takes the first free slot on the right, so the
-    // recovery is: detect the parked state, drop the stored position, and
-    // rebuild the item (reusing the runner layer + stored title/state).
+    // by seeding a large preferred position. The recovery is: detect the parked
+    // state, rebuild the item (reusing the runner layer + stored title/state),
+    // and seat it — at the user's own position on the first try, at the
+    // fallback slot once that position has demonstrably failed to bring it
+    // back. See StatusItemPlacement.
 
     // Parked means the item's window sits outside every screen. Occlusion is
     // NOT a usable signal here: the menu bar legitimately disappears in
@@ -159,31 +162,39 @@ public final class StatusItemController: NSObject {
 
     private func recreateItem() {
         NSLog("Tokcat: status item parked off-screen; rebuilding it")
+        // Read before removing: removeStatusItem() clears the item's saved
+        // position, so after that call there is nothing left to preserve and
+        // the placement rule would only ever see nil.
+        let stored = positions.storedPosition
         appearanceObservation = nil
         runner.removeFromSuperlayer()
         NSStatusBar.system.removeStatusItem(statusItem)
-        reseatPositionIfNeeded()
+        reseatPosition(stored: stored)
         statusItem = Self.makeStatusItem()
         configureItem()
     }
 
-    // The fallback value is the distance from the RIGHT edge. Removing the
-    // preference doesn't help: a brand-new item is inserted at the LEFT end of
-    // the status area, which on a crowded bar is exactly the hidden zone it
-    // just died in (verified empirically). A small offset lands it beside the
-    // system items, in the always-visible region. See StatusItemPlacement for
-    // when the stored position is left alone instead.
-    private func reseatPositionIfNeeded() {
-        // Read fresh: a drag performed between two rebuilds must re-arm the
-        // preserve branch rather than look like the position we already tried.
+    // The fallback value is the distance from the RIGHT edge. Leaving the
+    // preference empty doesn't help: a brand-new item with no stored position
+    // is inserted at the LEFT end of the status area, which on a crowded bar is
+    // exactly the hidden zone it just died in (verified empirically). A small
+    // offset lands it beside the system items, in the always-visible region.
+    //
+    // A position is therefore always written — the removal above cleared the
+    // key — and the only question StatusItemPlacement answers is whether that
+    // position is the user's own or our fallback slot.
+    private func reseatPosition(stored: Double?) {
         let decision = StatusItemPlacement.decide(
-            stored: positions.storedPosition,
+            stored: stored,
             seeded: positions.seededPosition,
             preserved: preservedPosition,
             fallback: Self.fallbackPosition)
         preservedPosition = decision.preserve
-        guard let seatAt = decision.seatAt else { return }
-        positions.seat(at: seatAt)
+        if decision.seatsOurOwnValue {
+            positions.seat(at: decision.seatAt)
+        } else {
+            positions.restore(at: decision.seatAt)
+        }
     }
 
     private var diagTimer: Timer?

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
@@ -5,26 +5,41 @@ import Foundation
 //
 // macOS stores the item's spot in "NSStatusItem Preferred Position <name>" —
 // the same preference it rewrites when the user Cmd-drags the item (see
-// StatusItemPositionStore). Hidden-item recovery used to overwrite that value
-// on every rebuild, which yanked the item back out of wherever the user had put
-// it. So: only reseat a value we wrote ourselves.
+// StatusItemPositionStore).
+//
+// The rebuild ALWAYS writes that preference, because the removal that starts
+// the rebuild clears it: measured on macOS 26, NSStatusBar.removeStatusItem()
+// leaves the item's saved position gone from the store. A rebuild that
+// "preserves" a position by writing nothing therefore hands the new item no
+// position at all, and the bar parks it off-screen until a later rebuild
+// seats something. So preserving the user's slot means seating that exact
+// value again, which is also what repopulates the key for the next launch.
 //
 // The one exception is a stored position that is itself the reason the item is
 // parked. That is only established when the *same* user position has already
 // had a rebuild to itself and the item never came back on screen since — which
 // is what `preserved` carries. A latching "we preserved once" flag was not
-// enough: the visibility watch also fires on display sleep and undock, so the
-// second rebuild it saw was usually an unrelated false positive, and it reset a
-// position the user still owned.
+// enough: the visibility watch also fires on unrelated relayouts, so the second
+// rebuild it saw was usually a false positive, and it reset a position the user
+// still owned.
 public enum StatusItemPlacement {
     public struct Decision: Equatable {
-        // The position to write, or nil to leave the stored one untouched.
-        public let seatAt: Double?
+        // The position to write. Always written — see above.
+        public let seatAt: Double
         // The user position this rebuild is giving a chance, carried into the
         // next decision. nil once the position has been overruled (we seated
         // the fallback); the caller also clears it as soon as the item is seen
         // on screen, which vindicates the position.
         public let preserve: Double?
+
+        // Whether `seatAt` is a value Tokcat picked rather than the user's own
+        // position being written back after the removal cleared it.
+        //
+        // Only our own value may be recorded in the seeded marker. Stamping a
+        // preserved user position as ours would make the *next* rebuild read it
+        // back as Tokcat's and drop the fallback on top of it — issue #94
+        // again, one rebuild later.
+        public var seatsOurOwnValue: Bool { preserve == nil }
     }
 
     public static func decide(
@@ -35,7 +50,7 @@ public enum StatusItemPlacement {
     ) -> Decision {
         guard let stored, stored != seeded else {
             // Nothing stored, or the value is one we seated ourselves:
-            // reseating it costs the user nothing.
+            // reseating the fallback costs the user nothing.
             return Decision(seatAt: fallback, preserve: nil)
         }
         if preserved == stored {
@@ -45,7 +60,8 @@ public enum StatusItemPlacement {
             return Decision(seatAt: fallback, preserve: nil)
         }
         // First rebuild for this position, or the user has dragged since the
-        // last one — give their choice a chance.
-        return Decision(seatAt: nil, preserve: stored)
+        // last one. Seat it again — that is what makes the rebuilt item
+        // reappear in the same slot instead of off-screen.
+        return Decision(seatAt: stored, preserve: stored)
     }
 }

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemPlacement.swift
@@ -3,30 +3,49 @@ import Foundation
 // Where a rebuilt status item should sit. Split out of StatusItemController
 // (and kept free of AppKit) so the rule has direct test coverage.
 //
-// macOS stores the item's spot in "NSStatusItem Preferred Position Item-0" —
-// the same preference it rewrites when the user Cmd-drags the item. Hidden-item
-// recovery used to overwrite that value on every rebuild, which yanked the item
-// back out of wherever the user had put it. So: only reseat a value we wrote
-// ourselves. If preserving the user's choice didn't bring the item back, the
-// stored position is itself the problem and the fallback slot wins.
+// macOS stores the item's spot in "NSStatusItem Preferred Position <name>" —
+// the same preference it rewrites when the user Cmd-drags the item (see
+// StatusItemPositionStore). Hidden-item recovery used to overwrite that value
+// on every rebuild, which yanked the item back out of wherever the user had put
+// it. So: only reseat a value we wrote ourselves.
+//
+// The one exception is a stored position that is itself the reason the item is
+// parked. That is only established when the *same* user position has already
+// had a rebuild to itself and the item never came back on screen since — which
+// is what `preserved` carries. A latching "we preserved once" flag was not
+// enough: the visibility watch also fires on display sleep and undock, so the
+// second rebuild it saw was usually an unrelated false positive, and it reset a
+// position the user still owned.
 public enum StatusItemPlacement {
     public struct Decision: Equatable {
         // The position to write, or nil to leave the stored one untouched.
         public let seatAt: Double?
-        // Carried back into the next decision.
-        public let preservedUserPosition: Bool
+        // The user position this rebuild is giving a chance, carried into the
+        // next decision. nil once the position has been overruled (we seated
+        // the fallback); the caller also clears it as soon as the item is seen
+        // on screen, which vindicates the position.
+        public let preserve: Double?
     }
 
     public static func decide(
         stored: Double?,
         seeded: Double?,
-        alreadyPreserved: Bool,
+        preserved: Double?,
         fallback: Double
     ) -> Decision {
-        let userMoved = stored != nil && stored != seeded
-        if userMoved, !alreadyPreserved {
-            return Decision(seatAt: nil, preservedUserPosition: true)
+        guard let stored, stored != seeded else {
+            // Nothing stored, or the value is one we seated ourselves:
+            // reseating it costs the user nothing.
+            return Decision(seatAt: fallback, preserve: nil)
         }
-        return Decision(seatAt: fallback, preservedUserPosition: false)
+        if preserved == stored {
+            // This exact position already had a rebuild to itself and the item
+            // is parked again without ever having come back: the position is
+            // the problem, so the fallback slot wins.
+            return Decision(seatAt: fallback, preserve: nil)
+        }
+        // First rebuild for this position, or the user has dragged since the
+        // last one — give their choice a chance.
+        return Decision(seatAt: nil, preserve: stored)
     }
 }

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemPositionStore.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemPositionStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+// The UserDefaults side of the menu-bar slot: which keys hold it, how a
+// pre-autosaveName install is migrated, and how a user's Cmd-drag is told
+// apart from a value Tokcat seated itself.
+//
+// macOS persists a status item's slot in "NSStatusItem Preferred Position
+// <autosaveName>" and rewrites that same preference when the user Cmd-drags
+// the item. Tokcat used to leave `autosaveName` unset and reach for AppKit's
+// generated "Item-0" name; that name is positional and is not reliably kept
+// across removeStatusItem()/quit, so a drag could be lost on a plain relaunch.
+// The item now carries a stable autosave name and this store owns the keys.
+//
+// Both keys are still read and written. The legacy value is migrated once so
+// upgrading users keep the slot they chose, and if a macOS version ignores our
+// autosave name and keeps maintaining the generated key, a fallback written
+// only to the new key would silently fail to move a parked item.
+public struct StatusItemPositionStore {
+    /// Stable autosave name for the status item. Also assigned to
+    /// `NSStatusItem.autosaveName`, which is what makes `positionKey` the key
+    /// macOS actually maintains.
+    public static let autosaveName = "TokcatStatusItem"
+
+    /// Where macOS stores the item's spot, derived from the autosave name.
+    public static let positionKey = "NSStatusItem Preferred Position \(autosaveName)"
+
+    /// The key AppKit generated for us before the autosave name existed.
+    public static let legacyPositionKey = "NSStatusItem Preferred Position Item-0"
+
+    /// The last position Tokcat seated itself; a stored value that differs
+    /// from it came from the user.
+    public static let seededPositionKey = "TokcatSeededStatusItemPosition"
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Copies a pre-autosaveName drag onto the autosave key.
+    ///
+    /// Must run *before* the first `NSStatusItem` is created: AppKit reads the
+    /// preference when it places the item, so a later write would not take
+    /// effect until the next launch.
+    public func migrateLegacyPositionIfNeeded() {
+        guard defaults.object(forKey: Self.positionKey) == nil,
+              let legacy = defaults.object(forKey: Self.legacyPositionKey) as? Double
+        else { return }
+        defaults.set(legacy, forKey: Self.positionKey)
+    }
+
+    /// The position macOS currently has on file. Read fresh on every rebuild so
+    /// a drag performed between two rebuilds is seen.
+    ///
+    /// A value that differs from `seededPosition` is by definition the user's,
+    /// so it wins over one we wrote — that is what picks the live key when only
+    /// one of the two is being maintained.
+    public var storedPosition: Double? {
+        let candidates = [Self.positionKey, Self.legacyPositionKey]
+            .compactMap { defaults.object(forKey: $0) as? Double }
+        let seeded = seededPosition
+        return candidates.first { $0 != seeded } ?? candidates.first
+    }
+
+    public var seededPosition: Double? {
+        defaults.object(forKey: Self.seededPositionKey) as? Double
+    }
+
+    /// Seats the item at `position` and records it as ours, so the next
+    /// decision knows the value is not a user drag.
+    public func seat(at position: Double) {
+        defaults.set(position, forKey: Self.positionKey)
+        defaults.set(position, forKey: Self.legacyPositionKey)
+        defaults.set(position, forKey: Self.seededPositionKey)
+    }
+}

--- a/native/LocalPackage/Sources/Model/AppShell/StatusItemPositionStore.swift
+++ b/native/LocalPackage/Sources/Model/AppShell/StatusItemPositionStore.swift
@@ -1,20 +1,21 @@
 import Foundation
 
-// The UserDefaults side of the menu-bar slot: which keys hold it, how a
+// The UserDefaults side of the menu-bar slot: which key holds it, how a
 // pre-autosaveName install is migrated, and how a user's Cmd-drag is told
 // apart from a value Tokcat seated itself.
 //
 // macOS persists a status item's slot in "NSStatusItem Preferred Position
 // <autosaveName>" and rewrites that same preference when the user Cmd-drags
-// the item. Tokcat used to leave `autosaveName` unset and reach for AppKit's
-// generated "Item-0" name; that name is positional and is not reliably kept
-// across removeStatusItem()/quit, so a drag could be lost on a plain relaunch.
-// The item now carries a stable autosave name and this store owns the keys.
+// the item. Tokcat used to leave `autosaveName` unset and inherit AppKit's
+// generated "Item-0" name; the item now carries a stable autosave name and
+// this store owns the keys.
 //
-// Both keys are still read and written. The legacy value is migrated once so
-// upgrading users keep the slot they chose, and if a macOS version ignores our
-// autosave name and keeps maintaining the generated key, a fallback written
-// only to the new key would silently fail to move a parked item.
+// One key is the source of truth. Measured on macOS 26: with `autosaveName`
+// set, the status bar reads and writes the autosave key only and never touches
+// the generated one. The legacy key is a migration input, not a second copy —
+// mirroring writes into it produced a value that went stale the moment the user
+// dragged, and reading that stale copy back is how a rebuild came to seat a
+// position the user never chose.
 public struct StatusItemPositionStore {
     /// Stable autosave name for the status item. Also assigned to
     /// `NSStatusItem.autosaveName`, which is what makes `positionKey` the key
@@ -24,12 +25,16 @@ public struct StatusItemPositionStore {
     /// Where macOS stores the item's spot, derived from the autosave name.
     public static let positionKey = "NSStatusItem Preferred Position \(autosaveName)"
 
-    /// The key AppKit generated for us before the autosave name existed.
+    /// The key AppKit generated for us before the autosave name existed. Read
+    /// once, by `migrateLegacyPositionIfNeeded()`, and never written.
     public static let legacyPositionKey = "NSStatusItem Preferred Position Item-0"
 
     /// The last position Tokcat seated itself; a stored value that differs
     /// from it came from the user.
     public static let seededPositionKey = "TokcatSeededStatusItemPosition"
+
+    /// Marks the one-shot legacy migration as done.
+    public static let legacyMigrationKey = "TokcatDidMigrateLegacyStatusItemPosition"
 
     private let defaults: UserDefaults
 
@@ -37,40 +42,54 @@ public struct StatusItemPositionStore {
         self.defaults = defaults
     }
 
-    /// Copies a pre-autosaveName drag onto the autosave key.
+    /// Copies a pre-autosaveName drag onto the autosave key, once.
     ///
     /// Must run *before* the first `NSStatusItem` is created: AppKit reads the
     /// preference when it places the item, so a later write would not take
     /// effect until the next launch.
+    ///
+    /// The "did it run" marker is what makes this one-shot. "The autosave key
+    /// is empty" cannot stand in for it, because removing a status item clears
+    /// that key — a launch that happened to start from a cleared key would
+    /// otherwise resurrect the stale `Item-0` value over a newer drag.
     public func migrateLegacyPositionIfNeeded() {
+        guard !defaults.bool(forKey: Self.legacyMigrationKey) else { return }
+        defaults.set(true, forKey: Self.legacyMigrationKey)
+        // Never overwrite a position already recorded under the autosave key:
+        // a user who has run a build with the autosave name and dragged since
+        // owns that value, and `Item-0` is stale by definition.
         guard defaults.object(forKey: Self.positionKey) == nil,
               let legacy = defaults.object(forKey: Self.legacyPositionKey) as? Double
         else { return }
         defaults.set(legacy, forKey: Self.positionKey)
     }
 
-    /// The position macOS currently has on file. Read fresh on every rebuild so
+    /// The position macOS currently has on file, read fresh on every rebuild so
     /// a drag performed between two rebuilds is seen.
     ///
-    /// A value that differs from `seededPosition` is by definition the user's,
-    /// so it wins over one we wrote — that is what picks the live key when only
-    /// one of the two is being maintained.
+    /// Must be read *before* the item is removed: the removal clears this key.
     public var storedPosition: Double? {
-        let candidates = [Self.positionKey, Self.legacyPositionKey]
-            .compactMap { defaults.object(forKey: $0) as? Double }
-        let seeded = seededPosition
-        return candidates.first { $0 != seeded } ?? candidates.first
+        defaults.object(forKey: Self.positionKey) as? Double
     }
 
     public var seededPosition: Double? {
         defaults.object(forKey: Self.seededPositionKey) as? Double
     }
 
-    /// Seats the item at `position` and records it as ours, so the next
-    /// decision knows the value is not a user drag.
+    /// Seats the item at a position Tokcat chose and records it as ours, so the
+    /// next decision knows the value is not a user drag.
     public func seat(at position: Double) {
         defaults.set(position, forKey: Self.positionKey)
-        defaults.set(position, forKey: Self.legacyPositionKey)
         defaults.set(position, forKey: Self.seededPositionKey)
+    }
+
+    /// Writes the user's own position back after a rebuild cleared it, without
+    /// claiming it as ours.
+    ///
+    /// The seeded marker is deliberately left alone: stamping a preserved user
+    /// position with it would make the next rebuild read that position back as
+    /// Tokcat's own and seat the fallback over it, which is the #94 snap-back.
+    public func restore(at position: Double) {
+        defaults.set(position, forKey: Self.positionKey)
     }
 }

--- a/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
@@ -6,11 +6,14 @@ import Testing
 // Hidden-item recovery rebuilds the status item, and the rebuild used to
 // overwrite the position preference unconditionally — the same preference macOS
 // rewrites when the user Cmd-drags the item. The item therefore jumped back
-// into the system-item zone every time the user moved it. These pin the rule
-// that fixed it, including the follow-up from issue #94: a boolean "we
-// preserved once" latch let the *second* rebuild reset a position the user
-// still owned, and the visibility watch also fires on display sleep / undock,
-// so that second rebuild was usually an unrelated false positive.
+// into the system-item zone every time the user moved it (issue #94).
+//
+// The rule that fixed it has two halves, and on-device measurement showed both
+// are needed. A boolean "we preserved once" latch let the *second* rebuild
+// reset a position the user still owned, so the decision carries *which*
+// position it spared. And preserving by writing nothing leaves the rebuilt item
+// with no position at all — removing a status item clears its saved position —
+// so preserving means seating that exact value again.
 @Suite struct StatusItemPlacementTests {
     private let fallback = 200.0
 
@@ -24,7 +27,7 @@ import Testing
 
     @Test func keepsAPositionTheUserDraggedTo() {
         let d = decide(stored: 500, seeded: fallback)
-        #expect(d.seatAt == nil)
+        #expect(d.seatAt == 500)
         #expect(d.preserve == 500)
     }
 
@@ -37,6 +40,7 @@ import Testing
     @Test func seatsWhenNoPositionIsStored() {
         let d = decide(stored: nil, seeded: nil)
         #expect(d.seatAt == fallback)
+        #expect(d.preserve == nil)
     }
 
     // Preserving the user's spot once is a courtesy, not a trap: if the item is
@@ -44,7 +48,7 @@ import Testing
     // never cleared `preserved` — that stored position is the problem.
     @Test func fallsBackWhenPreservingDidNotRecoverTheItem() {
         let first = decide(stored: 3000, seeded: fallback)
-        #expect(first.seatAt == nil)
+        #expect(first.seatAt == 3000)
         let second = decide(
             stored: 3000, seeded: fallback, preserved: first.preserve)
         #expect(second.seatAt == fallback)
@@ -52,14 +56,16 @@ import Testing
     }
 
     // #94: the item came back after the first rebuild, so StatusItemController
-    // cleared `preserved`. A later rebuild — display sleep, undock, anything
-    // that trips the hidden heuristic twice — must not spend the user's slot.
+    // cleared `preserved`. A later rebuild — undock, any relayout that trips
+    // the hidden heuristic twice — must not spend the user's slot. Writing the
+    // position back on every one of those rebuilds is what keeps the slot,
+    // since the removal clears it each time.
     @Test func twoRebuildsDoNotResetAPositionTheUserStillOwns() {
         let first = decide(stored: 500, seeded: fallback)
-        #expect(first.seatAt == nil)
+        #expect(first.seatAt == 500)
         // checkVisibility() saw the item on screen: preserved goes back to nil.
         let second = decide(stored: 500, seeded: fallback, preserved: nil)
-        #expect(second.seatAt == nil)
+        #expect(second.seatAt == 500)
         #expect(second.preserve == 500)
     }
 
@@ -70,12 +76,13 @@ import Testing
         #expect(first.preserve == 3000)
         let second = decide(
             stored: 800, seeded: fallback, preserved: first.preserve)
-        #expect(second.seatAt == nil)
+        #expect(second.seatAt == 800)
         #expect(second.preserve == 800)
         // Only that new position, unchanged and still parked, gives up.
         let third = decide(
             stored: 800, seeded: fallback, preserved: second.preserve)
         #expect(third.seatAt == fallback)
+        #expect(third.preserve == nil)
     }
 
     // Dragging back onto the fallback slot is indistinguishable from a value we
@@ -83,5 +90,33 @@ import Testing
     @Test func treatsTheSeededValueAsOursEvenWhenPreserved() {
         let d = decide(stored: fallback, seeded: fallback, preserved: fallback)
         #expect(d.seatAt == fallback)
+    }
+
+    // The decision never invents a slot: whatever it seats is either the
+    // position on file or our fallback, so a rebuild cannot move the item
+    // somewhere neither the user nor Tokcat chose.
+    @Test func onlyEverSeatsTheStoredPositionOrTheFallback() {
+        let positions: [Double?] = [nil, 0, fallback, 500, 3000, -80]
+        for stored in positions {
+            for seeded in positions {
+                for preserved in positions {
+                    let d = decide(
+                        stored: stored, seeded: seeded, preserved: preserved)
+                    #expect(Optional(d.seatAt) == stored || d.seatAt == fallback)
+                }
+            }
+        }
+    }
+
+    // `seatsOurOwnValue` is what tells StatusItemController whether to stamp the
+    // seeded marker. Getting it backwards on a preserved position would make the
+    // next rebuild read that position as ours and seat the fallback over it —
+    // #94, one rebuild later — so pin it to the two cases directly.
+    @Test func claimsOnlyTheFallbackAsOurs() {
+        #expect(decide(stored: 500, seeded: fallback).seatsOurOwnValue == false)
+        #expect(decide(stored: nil, seeded: nil).seatsOurOwnValue)
+        #expect(decide(stored: fallback, seeded: fallback).seatsOurOwnValue)
+        #expect(decide(stored: 3000, seeded: fallback, preserved: 3000)
+            .seatsOurOwnValue)
     }
 }

--- a/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/StatusItemPlacementTests.swift
@@ -4,31 +4,34 @@ import Testing
 @testable import Model
 
 // Hidden-item recovery rebuilds the status item, and the rebuild used to
-// overwrite "NSStatusItem Preferred Position Item-0" unconditionally — the
-// same preference macOS rewrites when the user Cmd-drags the item. The item
-// therefore jumped back into the system-item zone every time the user moved
-// it. These pin the rule that fixed it.
+// overwrite the position preference unconditionally — the same preference macOS
+// rewrites when the user Cmd-drags the item. The item therefore jumped back
+// into the system-item zone every time the user moved it. These pin the rule
+// that fixed it, including the follow-up from issue #94: a boolean "we
+// preserved once" latch let the *second* rebuild reset a position the user
+// still owned, and the visibility watch also fires on display sleep / undock,
+// so that second rebuild was usually an unrelated false positive.
 @Suite struct StatusItemPlacementTests {
     private let fallback = 200.0
 
     private func decide(
-        stored: Double?, seeded: Double?, alreadyPreserved: Bool = false
+        stored: Double?, seeded: Double?, preserved: Double? = nil
     ) -> StatusItemPlacement.Decision {
         StatusItemPlacement.decide(
             stored: stored, seeded: seeded,
-            alreadyPreserved: alreadyPreserved, fallback: fallback)
+            preserved: preserved, fallback: fallback)
     }
 
     @Test func keepsAPositionTheUserDraggedTo() {
         let d = decide(stored: 500, seeded: fallback)
         #expect(d.seatAt == nil)
-        #expect(d.preservedUserPosition)
+        #expect(d.preserve == 500)
     }
 
     @Test func reseatsAPositionWeWroteOurselves() {
         let d = decide(stored: fallback, seeded: fallback)
         #expect(d.seatAt == fallback)
-        #expect(!d.preservedUserPosition)
+        #expect(d.preserve == nil)
     }
 
     @Test func seatsWhenNoPositionIsStored() {
@@ -36,15 +39,49 @@ import Testing
         #expect(d.seatAt == fallback)
     }
 
-    // Preserving the user's spot once is a courtesy, not a trap: if the item
-    // is still parked on the next pass, that stored position is the problem.
+    // Preserving the user's spot once is a courtesy, not a trap: if the item is
+    // still parked on the next pass — i.e. it never came back, so the caller
+    // never cleared `preserved` — that stored position is the problem.
     @Test func fallsBackWhenPreservingDidNotRecoverTheItem() {
         let first = decide(stored: 3000, seeded: fallback)
         #expect(first.seatAt == nil)
         let second = decide(
-            stored: 3000, seeded: fallback,
-            alreadyPreserved: first.preservedUserPosition)
+            stored: 3000, seeded: fallback, preserved: first.preserve)
         #expect(second.seatAt == fallback)
-        #expect(!second.preservedUserPosition)
+        #expect(second.preserve == nil)
+    }
+
+    // #94: the item came back after the first rebuild, so StatusItemController
+    // cleared `preserved`. A later rebuild — display sleep, undock, anything
+    // that trips the hidden heuristic twice — must not spend the user's slot.
+    @Test func twoRebuildsDoNotResetAPositionTheUserStillOwns() {
+        let first = decide(stored: 500, seeded: fallback)
+        #expect(first.seatAt == nil)
+        // checkVisibility() saw the item on screen: preserved goes back to nil.
+        let second = decide(stored: 500, seeded: fallback, preserved: nil)
+        #expect(second.seatAt == nil)
+        #expect(second.preserve == 500)
+    }
+
+    // #94: a drag between two rebuilds re-arms the preserve branch, because the
+    // position now on file is not the one that already had its chance.
+    @Test func reArmsPreserveWhenTheUserMovesTheItemAgain() {
+        let first = decide(stored: 3000, seeded: fallback)
+        #expect(first.preserve == 3000)
+        let second = decide(
+            stored: 800, seeded: fallback, preserved: first.preserve)
+        #expect(second.seatAt == nil)
+        #expect(second.preserve == 800)
+        // Only that new position, unchanged and still parked, gives up.
+        let third = decide(
+            stored: 800, seeded: fallback, preserved: second.preserve)
+        #expect(third.seatAt == fallback)
+    }
+
+    // Dragging back onto the fallback slot is indistinguishable from a value we
+    // seated, and stays reseatable — harmless, since reseating it is a no-op.
+    @Test func treatsTheSeededValueAsOursEvenWhenPreserved() {
+        let d = decide(stored: fallback, seeded: fallback, preserved: fallback)
+        #expect(d.seatAt == fallback)
     }
 }

--- a/native/LocalPackage/Tests/ModelTests/StatusItemPositionStoreTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/StatusItemPositionStoreTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Model
+
+// The status item now carries a stable autosaveName, so macOS keys its slot off
+// a name we control instead of AppKit's positional "Item-0". These pin the
+// upgrade path (a drag recorded under the old key is not thrown away) and the
+// both-keys handling that keeps hidden-item recovery working if a macOS version
+// ignores the autosave name.
+@Suite struct StatusItemPositionStoreTests {
+    private let fallback = 200.0
+
+    private func makeDefaults() -> (UserDefaults, String) {
+        let name = "tokcat.tests.\(UUID().uuidString)"
+        return (UserDefaults(suiteName: name)!, name)
+    }
+
+    private func withStore(
+        _ body: (StatusItemPositionStore, UserDefaults) throws -> Void
+    ) throws {
+        let (defaults, name) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+        try body(StatusItemPositionStore(defaults: defaults), defaults)
+    }
+
+    @Test func derivesThePositionKeyFromTheAutosaveName() {
+        #expect(StatusItemPositionStore.autosaveName == "TokcatStatusItem")
+        #expect(StatusItemPositionStore.positionKey
+            == "NSStatusItem Preferred Position TokcatStatusItem")
+        #expect(StatusItemPositionStore.legacyPositionKey
+            == "NSStatusItem Preferred Position Item-0")
+    }
+
+    // Upgrading from a build with no autosaveName: the drag lives under the
+    // generated key and has to move over before the item is created.
+    @Test func migratesALegacyDragOntoTheAutosaveKey() throws {
+        try withStore { store, defaults in
+            defaults.set(640.0, forKey: StatusItemPositionStore.legacyPositionKey)
+            store.migrateLegacyPositionIfNeeded()
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.positionKey) as? Double == 640)
+            #expect(store.storedPosition == 640)
+        }
+    }
+
+    @Test func migrationNeverOverwritesTheAutosaveKey() throws {
+        try withStore { store, defaults in
+            defaults.set(900.0, forKey: StatusItemPositionStore.positionKey)
+            defaults.set(640.0, forKey: StatusItemPositionStore.legacyPositionKey)
+            store.migrateLegacyPositionIfNeeded()
+            #expect(store.storedPosition == 900)
+        }
+    }
+
+    @Test func migrationIsANoOpWithNothingStored() throws {
+        try withStore { store, defaults in
+            store.migrateLegacyPositionIfNeeded()
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.positionKey) as? Double == nil)
+            #expect(store.storedPosition == nil)
+        }
+    }
+
+    // If macOS keeps maintaining the generated key, a drag recorded there still
+    // has to read as a drag — the value that differs from what we seated wins.
+    @Test func prefersAStoredValueThatIsNotTheOneWeSeated() throws {
+        try withStore { store, defaults in
+            store.seat(at: fallback)
+            #expect(store.storedPosition == fallback)
+            #expect(store.seededPosition == fallback)
+            // AppKit records the user's drag under the legacy key only.
+            defaults.set(720.0, forKey: StatusItemPositionStore.legacyPositionKey)
+            #expect(store.storedPosition == 720)
+        }
+    }
+
+    // The mirror image: the autosave key is the live one and the legacy key is
+    // the stale copy seating left behind.
+    @Test func prefersTheAutosaveKeyWhenThatIsWhereTheDragLanded() throws {
+        try withStore { store, defaults in
+            store.seat(at: fallback)
+            defaults.set(720.0, forKey: StatusItemPositionStore.positionKey)
+            #expect(store.storedPosition == 720)
+        }
+    }
+
+    // Seating writes both keys: a fallback written only to the autosave key
+    // would silently fail to move the item on a macOS version that ignores it.
+    @Test func seatingWritesBothKeysAndRecordsTheValueAsOurs() throws {
+        try withStore { store, defaults in
+            store.seat(at: fallback)
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.positionKey) as? Double == fallback)
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.legacyPositionKey)
+                as? Double == fallback)
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.seededPositionKey)
+                as? Double == fallback)
+        }
+    }
+}

--- a/native/LocalPackage/Tests/ModelTests/StatusItemPositionStoreTests.swift
+++ b/native/LocalPackage/Tests/ModelTests/StatusItemPositionStoreTests.swift
@@ -3,11 +3,11 @@ import Testing
 
 @testable import Model
 
-// The status item now carries a stable autosaveName, so macOS keys its slot off
-// a name we control instead of AppKit's positional "Item-0". These pin the
-// upgrade path (a drag recorded under the old key is not thrown away) and the
-// both-keys handling that keeps hidden-item recovery working if a macOS version
-// ignores the autosave name.
+// The status item carries a stable autosaveName, so macOS keys its slot off a
+// name we control instead of AppKit's positional "Item-0". These pin the
+// upgrade path (a drag recorded under the old key is not thrown away, and is
+// not re-applied later over a newer one) and the single-source-of-truth rule:
+// the legacy key is a migration input, never a second copy to read back.
 @Suite struct StatusItemPositionStoreTests {
     private let fallback = 200.0
 
@@ -62,42 +62,77 @@ import Testing
         }
     }
 
-    // If macOS keeps maintaining the generated key, a drag recorded there still
-    // has to read as a drag — the value that differs from what we seated wins.
-    @Test func prefersAStoredValueThatIsNotTheOneWeSeated() throws {
+    // Removing a status item clears the autosave key, so "that key is empty"
+    // cannot stand in for "we never migrated" — a launch starting from a cleared
+    // key would otherwise copy the stale Item-0 value back over a newer drag.
+    @Test func migrationRunsOnlyOnceEvenIfTheAutosaveKeyIsClearedLater() throws {
         try withStore { store, defaults in
-            store.seat(at: fallback)
-            #expect(store.storedPosition == fallback)
-            #expect(store.seededPosition == fallback)
-            // AppKit records the user's drag under the legacy key only.
+            defaults.set(640.0, forKey: StatusItemPositionStore.legacyPositionKey)
+            store.migrateLegacyPositionIfNeeded()
+            #expect(store.storedPosition == 640)
+
+            // The user drags to 900; a rebuild's removal then clears the key.
+            defaults.set(900.0, forKey: StatusItemPositionStore.positionKey)
+            defaults.removeObject(forKey: StatusItemPositionStore.positionKey)
+            store.migrateLegacyPositionIfNeeded()
+            #expect(store.storedPosition == nil)
+        }
+    }
+
+    // The legacy key is a migration input, not a fallback source. Reading it
+    // back as "the stored position" is what let a rebuild seat a stale value the
+    // user had already dragged away from.
+    @Test func aLegacyValueAloneIsNotAStoredPosition() throws {
+        try withStore { store, defaults in
             defaults.set(720.0, forKey: StatusItemPositionStore.legacyPositionKey)
+            #expect(store.storedPosition == nil)
+            store.migrateLegacyPositionIfNeeded()
             #expect(store.storedPosition == 720)
         }
     }
 
-    // The mirror image: the autosave key is the live one and the legacy key is
-    // the stale copy seating left behind.
-    @Test func prefersTheAutosaveKeyWhenThatIsWhereTheDragLanded() throws {
+    @Test func seatingRecordsTheValueAsOursAndLeavesTheLegacyKeyAlone() throws {
         try withStore { store, defaults in
-            store.seat(at: fallback)
-            defaults.set(720.0, forKey: StatusItemPositionStore.positionKey)
-            #expect(store.storedPosition == 720)
-        }
-    }
-
-    // Seating writes both keys: a fallback written only to the autosave key
-    // would silently fail to move the item on a macOS version that ignores it.
-    @Test func seatingWritesBothKeysAndRecordsTheValueAsOurs() throws {
-        try withStore { store, defaults in
+            defaults.set(640.0, forKey: StatusItemPositionStore.legacyPositionKey)
             store.seat(at: fallback)
             #expect(defaults.object(
                 forKey: StatusItemPositionStore.positionKey) as? Double == fallback)
             #expect(defaults.object(
-                forKey: StatusItemPositionStore.legacyPositionKey)
+                forKey: StatusItemPositionStore.seededPositionKey)
                 as? Double == fallback)
+            #expect(store.seededPosition == fallback)
+            // Never written: macOS does not maintain it once autosaveName is set.
+            #expect(defaults.object(
+                forKey: StatusItemPositionStore.legacyPositionKey)
+                as? Double == 640)
+        }
+    }
+
+    // Putting the user's own position back must not claim it. If `restore`
+    // stamped the seeded marker, the next rebuild would read 500 as a value
+    // Tokcat seated and drop the fallback on top of it — the #94 snap-back,
+    // one rebuild later.
+    @Test func restoringAUserPositionDoesNotClaimItAsOurs() throws {
+        try withStore { store, defaults in
+            store.seat(at: fallback)
+            store.restore(at: 500)
+            #expect(store.storedPosition == 500)
+            #expect(store.seededPosition == fallback)
             #expect(defaults.object(
                 forKey: StatusItemPositionStore.seededPositionKey)
                 as? Double == fallback)
+        }
+    }
+
+    // The whole point of restoring: the removal cleared the key, and the value
+    // has to be back on file before the replacement item is created or the bar
+    // parks it off-screen.
+    @Test func restoringRepopulatesAClearedKey() throws {
+        try withStore { store, _ in
+            // Nothing on file: the removal that starts the rebuild cleared it.
+            #expect(store.storedPosition == nil)
+            store.restore(at: 611)
+            #expect(store.storedPosition == 611)
         }
     }
 }


### PR DESCRIPTION
🤖 **Claude Code**

## Summary

Fixes #94 — the item snapping back to the ~200 pt-from-right fallback slot after a Cmd-drag.

The mechanism is the one the owner established on-device on macOS 26 ([measurements](https://github.com/handlecusion/tokcat/pull/95#issuecomment-5647655793)), not the one this PR originally assumed:

**`NSStatusBar.removeStatusItem()` clears the item's saved position.** Hidden-item recovery removes and recreates the item, so every rebuild starts from an already-cleared placement key. `main`/0.3.3 reads `stored = nil`, concludes there is nothing of the user's to protect, and writes the fallback — the drag dies on the **first** rebuild. The `alreadyPreserved` latch this PR was originally built around was never involved.

That also means "preserve = write nothing" cannot work: it leaves the rebuilt item with no position at all, and the bar parks it off-screen until a later rebuild seats something. Measured on the first revision of this branch, that was a ~2 min disappearance — worse than the snap-back being fixed.

So the rule is now: **a rebuild always writes a position**, and the only question is whose. The user's own position is written back (which is also what repopulates the key for the next launch); the fallback wins only once that exact position has had a rebuild to itself and the item still hasn't come back.

## Changes

- **`StatusItemController.swift`**
  - `recreateItem()` reads `storedPosition` **before** `removeStatusItem()`; after that call there is nothing left to read.
  - `reseatPositionIfNeeded()` → `reseatPosition(stored:)`, which always writes.
  - `makeStatusItem()` sets a stable `autosaveName`; migration still runs in `init` before the first item exists.
  - `checkVisibility` clearing `preservedPosition` on the not-hidden path is unchanged — that is what stops an unrelated later rebuild from spending the user's slot.
- **`StatusItemPlacement.swift`** — `Decision.seatAt` is now a non-optional `Double`. Preserving a position means seating that exact value. New `seatsOurOwnValue`, which tells the controller whether the value may be recorded as Tokcat's.
- **`StatusItemPositionStore.swift`** — one source of truth. `storedPosition` reads the autosave key only; the legacy `Item-0` key is a migration input and is never written. `seat(at:)` (our fallback, stamps the seeded marker) is split from `restore(at:)` (the user's own position, deliberately does not). The migration is gated on its own marker key instead of "the autosave key is empty".
- **Tests** — the placement suite flips to the new `seatAt` expectations and keeps both #94 regressions; added "never seats anything but the stored position or the fallback" and a direct pin on `seatsOurOwnValue`. The store suite drops the two two-key-preference tests, and adds the legacy key not being a stored position, the migration being genuinely one-shot, and `restore` not claiming the value as ours.

## Assumptions

1. **The rebuilt item is placed from the key we just wrote.** This is the one link in the chain that no test here exercises: the measurements confirm macOS reads and writes `NSStatusItem Preferred Position TokcatStatusItem` with the autosave name set, and that it restores from it on launch, but "write the key between `removeStatusItem()` and the next `statusItem(withLength:)` and the new item lands there" is inferred from that, not observed.
2. **The stale `Item-0` value is left in place** rather than deleted after migration. It is never read again, and leaving it means a downgrade to 0.3.3 still finds a slot.
3. Exact `Double` comparison for positions, unchanged — AppKit writes back the value it read.

## How to verify

**CI** — `Swift build + test` on `macos-15` is the first machine that compiles this; nothing here was built locally (the session VM is Linux and has no Swift toolchain). The suites are pure logic over values and `UserDefaults`, so green is real coverage of the placement rule and the store — and of nothing above.

**Needs a Mac** (the owner's harness — CGEvent Cmd-drag, forced-rebuild hook, defaults poller — covers 1 and 2):

1. Real Cmd-drag left, then force one rebuild while the item is visible. The item must stay where it was dragged, and `defaults read com.handlecusion.tokcat "NSStatusItem Preferred Position TokcatStatusItem"` must still hold the dragged value. This is the assumption above, and the case the previous revision got wrong.
2. Parked seed (`3000` in the autosave key, `200` seeded): rebuild 1 re-seats 3000 and the item stays parked; rebuild 2 seats the fallback and it comes back.
3. Upgrade path: a machine with a dragged value under `…Item-0` and nothing under `…TokcatStatusItem` must not jump, and the new key must end up holding that number.

## Risks / follow-ups

- **Recovery from a genuinely bad drag takes two rebuilds, where `main` takes one** (measured: ~30 s → ~165 s). That is the direct cost of giving the user's position a chance before overruling it, which is what #94 asks for. The earlier claim that this was "no change in practice" was wrong.
- A position that is bad only on *some* display configs gets a fresh preserve-and-rebuild pair on each flip, i.e. one extra parked window per flip, rather than being remembered as bad. Remembering it the other way is what produced #94.
- Not addressed (out of scope for #94): `checkVisibility`'s two-sample heuristic can still fire without the item being genuinely unreachable. This change makes those false positives harmless instead of eliminating them — and the measurements found display sleep is *not* one of them, so the trigger in the original report is still unidentified.

Closes #94

<!-- claude-harness kind=FOLLOW_UP issue=95 -->
