### PR TITLE
Measure the three cloud-session usage sources before wiring one into the graph

### DIFF
--- a/native/LocalPackage/Sources/Collector/CloudSessions.swift
+++ b/native/LocalPackage/Sources/Collector/CloudSessions.swift
@@ -1,0 +1,312 @@
+import DataSource
+import Foundation
+
+// Cloud-session measurement surface (dev probe; not wired into the graph).
+//
+// Claude Code cloud sessions run either in Anthropic's VM or — when the
+// account has a Remote Control bridge registered — on this Mac, inside
+// `<repo>/.claude/worktrees/bridge-cse_<id>`. Only the bridged case leaves a
+// transcript under `~/.claude/projects/`, and today the graph counts it as an
+// ordinary `claude` session.
+//
+// The measurement has two axes, because both decide the answer:
+//
+//   marker   — what counts as evidence of a cloud session
+//     .pathSlug        the project directory encodes the worktree path
+//                      (`.claude/worktrees/bridge-cse_<id>`, which the slug
+//                      flattens to `-claude-worktrees-bridge-cse-<id>`)
+//     .cwdField        a row's structured `cwd` is the bridge worktree
+//     .rawSubstring    the marker bytes appear anywhere in the file
+//     .bridgeSessionID any `bridgeSessionId` whose value starts `cse_`
+//
+//   variant  — how much of each transcript is read to apply the marker
+//     .noRead          path only, zero reads
+//     .headSniff       first `headBytes`
+//     .fullScan        whole file (ground truth, and the cost ceiling)
+//
+// `.rawSubstring` and `.bridgeSessionID` are the two traps: transcripts of
+// ordinary local sessions quote the worktree path in shell output, and every
+// session the Claude app bridges locally carries a `cse_` bridge id.
+//
+// `tokcat-dump cloud-probe` renders this as JSON; the numbers in the PR come
+// from that command.
+
+/// What counts as evidence that a transcript belongs to a cloud session.
+public enum CloudMarker: String, Sendable, Codable, CaseIterable {
+    case pathSlug
+    case cwdField
+    case rawSubstring
+    case bridgeSessionID
+}
+
+/// How much of a transcript is read before the marker is applied.
+public enum CloudScanVariant: String, Sendable, Codable, CaseIterable {
+    case noRead
+    case headSniff
+    case fullScan
+}
+
+public struct CloudTranscriptReport: Sendable, Codable {
+    public var path: String
+    public var fileBytes: Int64
+    public var messages: Int
+    public var tokens: TokenBreakdown
+    public var cost: Double
+    public var dates: [String]
+}
+
+public struct CloudDayReport: Sendable, Codable {
+    public var date: String
+    public var messages: Int
+    public var tokens: Int64
+    public var cost: Double
+}
+
+public struct CloudScanReport: Sendable, Codable {
+    public var marker: CloudMarker
+    public var variant: CloudScanVariant
+    /// Bytes read per candidate file before the marker decision.
+    public var headBytes: Int
+    public var roots: [String]
+    public var filesCandidate: Int
+    /// Sum of the on-disk sizes of every candidate transcript.
+    public var candidateBytes: Int64
+    /// Bytes this (marker, variant) pair actually read.
+    public var bytesRead: Int64
+    public var wallMs: Double
+    public var transcripts: [CloudTranscriptReport]
+    public var totalMessages: Int
+    public var totalTokens: Int64
+    public var totalCost: Double
+    public var daily: [CloudDayReport]
+}
+
+public enum CloudSessionScanner {
+    /// Scan the Claude transcript roots for cloud-session transcripts.
+    ///
+    /// `home` overrides HOME so fixtures replay deterministically.
+    public static func scan(
+        marker: CloudMarker,
+        variant: CloudScanVariant,
+        headBytes: Int = 8 * 1024,
+        home: String? = nil
+    ) -> CloudScanReport {
+        let root = home ?? homeDir() ?? ""
+        let started = DispatchTime.now().uptimeNanoseconds
+        var files: [String] = []
+        var roots: [String] = []
+        for transcriptRoot in claudeTranscriptRoots(root) {
+            let found = collectFiles(transcriptRoot) { path in
+                let ext = rustExtension(path)
+                return ext == "jsonl" || ext == "json"
+            }
+            if !found.isEmpty { roots.append(transcriptRoot) }
+            files.append(contentsOf: found)
+        }
+        files.sort(by: utf8Less)
+
+        var candidateBytes: Int64 = 0
+        var bytesRead: Int64 = 0
+        var detected: [String] = []
+        for path in files {
+            candidateBytes += fileSizeBytes(path)
+            let effective = marker == .pathSlug ? CloudScanVariant.noRead : variant
+            switch effective {
+            case .noRead:
+                if pathIsCloudWorktree(path) { detected.append(path) }
+            case .headSniff:
+                let (hit, read) = fileMatches(path, marker: marker, limit: headBytes)
+                bytesRead += read
+                if hit { detected.append(path) }
+            case .fullScan:
+                let (hit, read) = fileMatches(path, marker: marker, limit: nil)
+                bytesRead += read
+                if hit { detected.append(path) }
+            }
+        }
+
+        var transcripts: [CloudTranscriptReport] = []
+        var cloudMessages: [UsageMessage] = []
+        for path in detected {
+            let messages = applyPricing(dedupMessages(parseClaudeFile(path)))
+            guard !messages.isEmpty else { continue }
+            var tokens = TokenBreakdown()
+            var cost = 0.0
+            var dates = Set<String>()
+            for message in messages {
+                tokens.addClamped(message.tokens)
+                cost += message.cost
+                dates.insert(message.date)
+            }
+            cloudMessages.append(contentsOf: messages)
+            transcripts.append(
+                CloudTranscriptReport(
+                    path: path,
+                    fileBytes: fileSizeBytes(path),
+                    messages: messages.count,
+                    tokens: tokens,
+                    cost: cost,
+                    dates: dates.sorted(by: utf8Less)))
+        }
+
+        // Same aggregation the graph would use, so the daily rows are directly
+        // comparable with `tokcat-dump graph` output.
+        let payload = buildPayload(cloudMessages)
+        let daily = payload.contributions.map {
+            CloudDayReport(
+                date: $0.date,
+                messages: Int($0.totals.messages),
+                tokens: $0.totals.tokens,
+                cost: $0.totals.cost)
+        }
+
+        return CloudScanReport(
+            marker: marker,
+            variant: variant,
+            headBytes: variant == .headSniff ? headBytes : 0,
+            roots: roots,
+            filesCandidate: files.count,
+            candidateBytes: candidateBytes,
+            bytesRead: bytesRead,
+            wallMs: Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000.0,
+            transcripts: transcripts,
+            totalMessages: cloudMessages.count,
+            totalTokens: cloudMessages.reduce(0) { satAdd($0, $1.tokens.total) },
+            totalCost: cloudMessages.reduce(0.0) { $0 + $1.cost },
+            daily: daily)
+    }
+}
+
+// MARK: - Markers
+
+/// The bridge worktree a cloud session runs in, as it appears in a real path
+/// (`.../.claude/worktrees/bridge-cse_01TS…`). The project-directory slug
+/// flattens it to `-claude-worktrees-bridge-cse-01TS…`.
+private let cloudWorktreePathMarker = Array("worktrees/bridge-cse".utf8)
+private let cloudWorktreeSlugMarker = Array("worktrees-bridge-cse".utf8)
+private let bridgeSessionKey = Array("bridgeSessionId".utf8)
+private let cloudEnvPrefix = Array("cse_".utf8)
+/// How far past `bridgeSessionId` the `cse_` value may sit (JSON spacing slop).
+private let bridgeValueWindow = 200
+private let cwdKey = Array("\"cwd\"".utf8)
+
+/// Zero-read marker: the project directory slug encodes the cloud worktree.
+func pathIsCloudWorktree(_ path: String) -> Bool {
+    path.contains("worktrees-bridge-cse") || path.contains("worktrees/bridge-cse")
+}
+
+/// Read `limit` bytes (nil = whole file) and apply `marker`.
+func fileMatches(
+    _ path: String, marker: CloudMarker, limit: Int?
+) -> (Bool, Int64) {
+    let data: Data
+    let read: Int64
+    if let limit {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return (false, 0) }
+        defer { try? handle.close() }
+        guard let head = try? handle.read(upToCount: max(limit, 1)), !head.isEmpty else {
+            return (false, 0)
+        }
+        data = head
+        read = Int64(head.count)
+    } else {
+        guard let whole = FileManager.default.contents(atPath: path) else { return (false, 0) }
+        data = whole
+        read = Int64(whole.count)
+    }
+    let hit = data.withUnsafeBytes { raw -> Bool in
+        guard let base = raw.bindMemory(to: UInt8.self).baseAddress else { return false }
+        let bytes = UnsafeBufferPointer(start: base, count: raw.count)
+        switch marker {
+        case .pathSlug:
+            return pathIsCloudWorktree(path)
+        case .rawSubstring:
+            return containsCloudWorktreePath(bytes)
+        case .cwdField:
+            return containsCloudWorktreeCwd(bytes)
+        case .bridgeSessionID:
+            return containsBridgeCloudSessionID(bytes)
+        }
+    }
+    return (hit, read)
+}
+
+/// Raw bytes anywhere: over-matches transcripts that merely quote the path.
+func containsCloudWorktreePath(_ bytes: UnsafeBufferPointer<UInt8>) -> Bool {
+    indexOfBytes(bytes, cloudWorktreePathMarker, from: 0) != nil
+        || indexOfBytes(bytes, cloudWorktreeSlugMarker, from: 0) != nil
+}
+
+/// Structured check: some row's `cwd` value is the cloud worktree. Reads the
+/// JSON string itself, so a path quoted inside a tool result — `git worktree
+/// list` output, an `ls` error — stays a non-match.
+func containsCloudWorktreeCwd(_ bytes: UnsafeBufferPointer<UInt8>) -> Bool {
+    let quote = UInt8(ascii: "\"")
+    let colon = UInt8(ascii: ":")
+    let space = UInt8(ascii: " ")
+    /// Longest `cwd` value worth considering (paths, not payloads).
+    let valueLimit = 1024
+    var cursor = 0
+    while let key = indexOfBytes(bytes, cwdKey, from: cursor) {
+        var i = key + cwdKey.count
+        while i < bytes.count, bytes[i] == colon || bytes[i] == space { i += 1 }
+        if i < bytes.count, bytes[i] == quote {
+            let valueStart = i + 1
+            var end = valueStart
+            while end < bytes.count, bytes[end] != quote, end - valueStart < valueLimit {
+                end += 1
+            }
+            if end < bytes.count, end - valueStart < valueLimit {
+                let value = UnsafeBufferPointer(rebasing: bytes[valueStart..<end])
+                if indexOfBytes(value, cloudWorktreePathMarker, from: 0) != nil
+                    || indexOfBytes(value, cloudWorktreeSlugMarker, from: 0) != nil
+                {
+                    return true
+                }
+            }
+        }
+        cursor = key + cwdKey.count
+    }
+    return false
+}
+
+/// A `bridgeSessionId` whose value starts with the cloud-session-env prefix.
+/// Over-matches: locally bridged sessions carry one too.
+func containsBridgeCloudSessionID(_ bytes: UnsafeBufferPointer<UInt8>) -> Bool {
+    var cursor = 0
+    while let key = indexOfBytes(bytes, bridgeSessionKey, from: cursor) {
+        let windowEnd = min(bytes.count, key + bridgeSessionKey.count + bridgeValueWindow)
+        if indexOfBytes(bytes, cloudEnvPrefix, from: key, limit: windowEnd) != nil {
+            return true
+        }
+        cursor = key + bridgeSessionKey.count
+    }
+    return false
+}
+
+/// First index of `needle` in `bytes` at or after `from`, bounded by `limit`.
+func indexOfBytes(
+    _ bytes: UnsafeBufferPointer<UInt8>, _ needle: [UInt8], from: Int, limit: Int? = nil
+) -> Int? {
+    guard !needle.isEmpty, bytes.count >= needle.count else { return nil }
+    let end = min(bytes.count, limit ?? bytes.count) - needle.count
+    var i = max(from, 0)
+    while i <= end {
+        if bytes[i] == needle[0] {
+            var matched = true
+            for j in 1..<needle.count where bytes[i + j] != needle[j] {
+                matched = false
+                break
+            }
+            if matched { return i }
+        }
+        i += 1
+    }
+    return nil
+}
+
+func fileSizeBytes(_ path: String) -> Int64 {
+    var sb = stat()
+    guard stat(path, &sb) == 0 else { return 0 }
+    return max(Int64(sb.st_size), 0)
+}

--- a/native/LocalPackage/Sources/Collector/Parsers/ClaudeParser.swift
+++ b/native/LocalPackage/Sources/Collector/Parsers/ClaudeParser.swift
@@ -8,15 +8,11 @@ enum ClaudeParser: UsageParser {
 
     static func parse(_ cache: UsageCache?) -> [UsageMessage] {
         guard let home = homeDir() else { return [] }
-        let roots = [
-            joinPath(joinPath(home, ".claude"), "projects"),
-            joinPath(joinPath(home, ".claude"), "transcripts"),
-        ]
         // Files parse independently (the merge map below is per-file), so
         // parse concurrently; parseFilesInOrder keeps the roots-then-sorted
         // concatenation order the downstream first-wins dedup depends on.
         var files: [String] = []
-        for root in roots {
+        for root in claudeTranscriptRoots(home) {
             files.append(contentsOf: collectFiles(root) { p in
                 let ext = rustExtension(p)
                 return ext == "jsonl" || ext == "json"

--- a/native/LocalPackage/Sources/Collector/Quota/CodexCloudUsage.swift
+++ b/native/LocalPackage/Sources/Collector/Quota/CodexCloudUsage.swift
@@ -1,0 +1,225 @@
+import DataSource
+import Foundation
+
+// Codex Cloud usage, from the same authenticated backend the app uses.
+//
+// `codex cloud list` reports what tasks exist but no usage; the per-thread
+// usage endpoint (`/wham/usage/thread_usage/query`) answers 403 with the CLI's
+// OAuth token. What does answer is the account's daily breakdown:
+//
+//   GET /backend-api/wham/usage/daily-token-usage-breakdown
+//       ?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD&group_by=day
+//
+// one entry per day, each with `product_surface_usage_values` split by where
+// the work ran — `web`/`work_web`/`mobile` are cloud surfaces, `cli`/`vscode`/
+// `desktop_app`/`exec` are this Mac. Units are percent of the plan's allowance
+// (`units: "percent"`), not tokens: the same number the account's own usage
+// page shows, so a cloud row here is comparable with the quota card rather
+// than with the token graph.
+//
+// Verified against the app's own call shape (ChatGPT.app app.asar):
+// `safeGet('/wham/usage/daily-token-usage-breakdown', {parameters: {query:
+// {start_date, end_date, group_by: 'day'}}})`.
+
+private let codexDailyUsageURL = "https://chatgpt.com/backend-api/wham/usage/daily-token-usage-breakdown"
+
+/// Surfaces that are not this Mac: Codex Cloud web/mobile, integrations, and
+/// background agents. Everything else ran through a local client Tokcat
+/// already reads from disk.
+public let codexCloudSurfaces: Set<String> = [
+    "web", "work_web", "mobile", "work_mobile",
+    "slack", "linear", "jetbrains", "github", "github_code_review",
+    "agent_identity", "sdk",
+]
+
+public struct CodexDailyModel: Sendable, Codable, Equatable {
+    public var model: String
+    public var speed: String?
+    public var credits: Double
+}
+
+public struct CodexDailyUsage: Sendable, Codable, Equatable {
+    public var date: String
+    public var surfaces: [String: Double]
+    public var models: [CodexDailyModel]
+    /// Sum of the cloud surfaces in `surfaces`.
+    public var cloudPercent: Double
+    /// Sum of the local surfaces in `surfaces`.
+    public var localPercent: Double
+}
+
+public struct CodexCloudUsageReport: Sendable, Codable {
+    /// Always "percent" today: the breakdown is plan consumption, not tokens.
+    public var units: String
+    public var groupBy: String
+    public var days: [CodexDailyUsage]
+    public var cloudTotalPercent: Double
+    public var localTotalPercent: Double
+    /// Days where any cloud surface was non-zero.
+    public var cloudDays: Int
+}
+
+public enum CodexCloudUsageError: Error, CustomStringConvertible {
+    case notConfigured
+    case http(Int)
+    case decode(String)
+
+    public var description: String {
+        switch self {
+        case .notConfigured:
+            return "Codex OAuth credentials not found. Run `codex` to authenticate."
+        case .http(let status):
+            return "Codex daily usage API returned \(status)."
+        case .decode(let detail):
+            return "decode Codex daily usage response: \(detail)"
+        }
+    }
+}
+
+/// Wire shape of the endpoint (snake_case, like the rest of the Codex API).
+struct CodexDailyUsageResponse: Decodable {
+    var units: String?
+    var groupBy: String?
+    var data: [CodexDailyUsageEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case units
+        case groupBy = "group_by"
+        case data
+    }
+}
+
+struct CodexDailyUsageEntry: Decodable {
+    var date: String
+    var productSurfaceUsageValues: [String: Double]
+    var models: [CodexDailyUsageEntryModel]
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case productSurfaceUsageValues = "product_surface_usage_values"
+        case models
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = (try? container.decode(String.self, forKey: .date)) ?? ""
+        // Lenient: an unseen surface must not fail the whole breakdown.
+        productSurfaceUsageValues =
+            (try? container.decode([String: Double].self, forKey: .productSurfaceUsageValues))
+            ?? [:]
+        models =
+            (try? container.decode([CodexDailyUsageEntryModel].self, forKey: .models)) ?? []
+    }
+}
+
+struct CodexDailyUsageEntryModel: Decodable {
+    var model: String
+    var speed: String?
+    var credits: Double?
+}
+
+public enum CodexCloudUsageProvider {
+    public static var isConfigured: Bool {
+        FileManager.default.fileExists(
+            atPath: codexHome().appendingPathComponent("auth.json").path)
+    }
+
+    /// `YYYY-MM-DD` in UTC — the endpoint's date parameters.
+    static func dateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    /// Daily plan consumption for the last `days` days, split by surface.
+    public static func fetch(days: Int = 30, now: Date = Date()) async throws
+        -> CodexCloudUsageReport
+    {
+        guard isConfigured else { throw CodexCloudUsageError.notConfigured }
+        var credentials = try CodexQuotaProvider.loadCodexCredentials()
+        if CodexQuotaProvider.codexCredentialsNeedRefresh(lastRefresh: credentials.lastRefresh) {
+            let refreshToken = credentials.refreshToken ?? ""
+            if refreshToken.isEmpty {
+                throw QuotaError(
+                    "Codex OAuth token needs refresh but auth.json has no refresh token.")
+            }
+            credentials = try await CodexQuotaProvider.refreshCodexCredentials(credentials)
+        }
+
+        let end = dateString(now)
+        let start = dateString(
+            Calendar(identifier: .gregorian).date(byAdding: .day, value: -(max(days, 1) - 1), to: now)
+                ?? now)
+        var components = URLComponents(string: codexDailyUsageURL)!
+        components.queryItems = [
+            URLQueryItem(name: "start_date", value: start),
+            URLQueryItem(name: "end_date", value: end),
+            URLQueryItem(name: "group_by", value: "day"),
+        ]
+        var request = URLRequest(url: components.url!)
+        request.timeoutInterval = 30
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Tokcat", forHTTPHeaderField: "User-Agent")
+        if let accountId = credentials.accountId, !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        let (status, body) = try await QuotaHTTP.send(request)
+        if status == 401 || status == 403 {
+            throw QuotaError("Codex OAuth token expired or invalid. Run `codex` to log in again.")
+        }
+        guard (200..<300).contains(status) else { throw CodexCloudUsageError.http(status) }
+        let response: CodexDailyUsageResponse
+        do {
+            response = try JSONDecoder().decode(CodexDailyUsageResponse.self, from: body)
+        } catch {
+            throw CodexCloudUsageError.decode("\(error)")
+        }
+        return report(from: response)
+    }
+
+    /// Split each day into cloud vs local surfaces. Pure, so the tests can pin
+    /// the classification without a network round trip.
+    static func report(from response: CodexDailyUsageResponse) -> CodexCloudUsageReport {
+        var days: [CodexDailyUsage] = []
+        var cloudTotal = 0.0
+        var localTotal = 0.0
+        var cloudDays = 0
+        for entry in response.data where !entry.date.isEmpty {
+            var cloud = 0.0
+            var local = 0.0
+            for (surface, value) in entry.productSurfaceUsageValues {
+                if codexCloudSurfaces.contains(surface) {
+                    cloud += max(value, 0)
+                } else {
+                    local += max(value, 0)
+                }
+            }
+            if cloud > 0 { cloudDays += 1 }
+            cloudTotal += cloud
+            localTotal += local
+            days.append(
+                CodexDailyUsage(
+                    date: entry.date,
+                    surfaces: entry.productSurfaceUsageValues,
+                    models: entry.models.map {
+                        CodexDailyModel(
+                            model: $0.model, speed: $0.speed, credits: $0.credits ?? 0)
+                    },
+                    cloudPercent: cloud,
+                    localPercent: local))
+        }
+        days.sort { $0.date < $1.date }
+        return CodexCloudUsageReport(
+            units: response.units ?? "percent",
+            groupBy: response.groupBy ?? "day",
+            days: days,
+            cloudTotalPercent: cloudTotal,
+            localTotalPercent: localTotal,
+            cloudDays: cloudDays)
+    }
+}

--- a/native/LocalPackage/Sources/Collector/Support/FileScan.swift
+++ b/native/LocalPackage/Sources/Collector/Support/FileScan.swift
@@ -132,6 +132,16 @@ func xdgDataHome(_ home: String) -> String {
     return joinPath(joinPath(home, ".local"), "share")
 }
 
+/// Claude Code transcript roots. Cloud sessions bridged to this Mac land in
+/// the same tree as local ones (`projects/<cwd slug>/<session>.jsonl`), which
+/// is why the graph can only tell them apart by content or slug.
+func claudeTranscriptRoots(_ home: String) -> [String] {
+    [
+        joinPath(joinPath(home, ".claude"), "projects"),
+        joinPath(joinPath(home, ".claude"), "transcripts"),
+    ]
+}
+
 /// Port of orca_codex_homes (usage_graph.rs:2251-2281): every immediate
 /// child of `<data dir>/orca/codex-runtime-home/` holding a sessions or
 /// archived_sessions directory.

--- a/native/LocalPackage/Sources/Collector/UsageGraph.swift
+++ b/native/LocalPackage/Sources/Collector/UsageGraph.swift
@@ -70,35 +70,41 @@ public enum UsageGraph {
             messages.append(contentsOf: entry.parse(cache))
         }
         cache?.endRun()
-        // inferProvider and bundledPrice are pure per (model, provider) but
-        // string-scan heavy; memoize across the ~10^5-message pass.
-        var providerCache: [String: String] = [:]
-        var priceCache: [String: Price] = [:]
-        return dedupMessages(messages).compactMap { msg -> UsageMessage? in
-            var msg = msg
-            if msg.timestampMs <= 0 || msg.totalTokens <= 0 { return nil }
-            if rustTrim(msg.providerId).isEmpty {
-                if let provider = providerCache[msg.modelId] {
-                    msg.providerId = provider
-                } else {
-                    let provider = inferProvider(msg.modelId)
-                    providerCache[msg.modelId] = provider
-                    msg.providerId = provider
-                }
+        return applyPricing(dedupMessages(messages))
+    }
+}
+
+/// Pipeline tail shared by the graph and the cloud-session probe: drop
+/// timestamp-less/empty rows, infer the provider, then price the tokens.
+/// `inferProvider` and `bundledPrice` are pure per (model, provider) but
+/// string-scan heavy; memoize across the ~10^5-message pass.
+func applyPricing(_ messages: [UsageMessage]) -> [UsageMessage] {
+    var providerCache: [String: String] = [:]
+    var priceCache: [String: Price] = [:]
+    return messages.compactMap { msg -> UsageMessage? in
+        var msg = msg
+        if msg.timestampMs <= 0 || msg.totalTokens <= 0 { return nil }
+        if rustTrim(msg.providerId).isEmpty {
+            if let provider = providerCache[msg.modelId] {
+                msg.providerId = provider
+            } else {
+                let provider = inferProvider(msg.modelId)
+                providerCache[msg.modelId] = provider
+                msg.providerId = provider
             }
-            if msg.cost <= 0.0 {
-                let key = "\(msg.modelId)\u{0}\(msg.providerId)"
-                let price: Price
-                if let cached = priceCache[key] {
-                    price = cached
-                } else {
-                    price = bundledPrice(model: msg.modelId, provider: msg.providerId)
-                    priceCache[key] = price
-                }
-                msg.cost = estimateCost(price: price, tokens: msg.tokens)
-            }
-            return msg
         }
+        if msg.cost <= 0.0 {
+            let key = "\(msg.modelId)\u{0}\(msg.providerId)"
+            let price: Price
+            if let cached = priceCache[key] {
+                price = cached
+            } else {
+                price = bundledPrice(model: msg.modelId, provider: msg.providerId)
+                priceCache[key] = price
+            }
+            msg.cost = estimateCost(price: price, tokens: msg.tokens)
+        }
+        return msg
     }
 }
 

--- a/native/LocalPackage/Sources/tokcat-dump/CloudProbe.swift
+++ b/native/LocalPackage/Sources/tokcat-dump/CloudProbe.swift
@@ -105,6 +105,7 @@ struct CloudShare: Encodable {
 }
 
 struct SourceB: Encodable {
+    // Inventory: which cloud tasks exist (no usage in this payload).
     var command: String
     var exitCode: Int32?
     var wallMs: Double
@@ -112,17 +113,72 @@ struct SourceB: Encodable {
     var tasks: Int
     var taskFields: [String]
     var usageBearingFields: [String]
-    var detail: String?
+    var inventoryError: String?
+    // Daily usage: plan percent by product surface, cloud surfaces split out.
+    var usageCommand: String
+    var usageWallMs: Double
+    var units: String?
+    var days: Int
+    var cloudDays: Int
+    var cloudTotalPercent: Double
+    var localTotalPercent: Double
+    var dayDetail: [CloudDayPercent]
+    var usageError: String?
+    /// Tokens-per-percent implied by the local surfaces, and the cloud token
+    /// estimate it would produce. Calibration, not measurement.
+    var calibration: [CalibrationDay]
+    var impliedTokensPerPercent: Double?
+    var cloudTokensEstimate: Int64?
 
     enum CodingKeys: String, CodingKey {
-        case command
+        case command, tasks, units, days, calibration
         case exitCode = "exit_code"
         case wallMs = "wall_ms"
         case stdoutBytes = "stdout_bytes"
-        case tasks
         case taskFields = "task_fields"
         case usageBearingFields = "usage_bearing_fields"
-        case detail
+        case inventoryError = "inventory_error"
+        case usageCommand = "usage_command"
+        case usageWallMs = "usage_wall_ms"
+        case cloudDays = "cloud_days"
+        case cloudTotalPercent = "cloud_total_percent"
+        case localTotalPercent = "local_total_percent"
+        case dayDetail = "day_detail"
+        case usageError = "usage_error"
+        case impliedTokensPerPercent = "implied_tokens_per_percent"
+        case cloudTokensEstimate = "cloud_tokens_estimate"
+    }
+}
+
+struct CloudDayPercent: Encodable {
+    var date: String
+    var cloudPercent: Double
+    var localPercent: Double
+    var cloudSurfaces: [String: Double]
+    var localSurfaces: [String: Double]
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case cloudPercent = "cloud_percent"
+        case localPercent = "local_percent"
+        case cloudSurfaces = "cloud_surfaces"
+        case localSurfaces = "local_surfaces"
+    }
+}
+
+/// One day of the calibration: what the account's own percent says about the
+/// local surfaces vs what Tokcat counted from local logs.
+struct CalibrationDay: Encodable {
+    var date: String
+    var localPercent: Double
+    var localTokens: Int64
+    var tokensPerPercent: Double
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case localPercent = "local_percent"
+        case localTokens = "local_tokens"
+        case tokensPerPercent = "tokens_per_percent"
     }
 }
 
@@ -152,7 +208,7 @@ func runCloudProbe(days: Int, only: [String], skipNetwork: Bool) {
         let output = CloudProbeOutput(
             measuredAt: ISO8601DateFormatter().string(from: Date()),
             sourceA: measureSourceA(days: days, only: only),
-            sourceB: skipNetwork ? nil : measureSourceB(),
+            sourceB: skipNetwork ? nil : await measureSourceB(),
             sourceC: skipNetwork ? nil : await measureSourceC())
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
@@ -300,14 +356,88 @@ private func measureSourceA(days: Int, only: [String]) -> SourceA {
 
 // MARK: - B. codex cloud task list
 
-private func measureSourceB() -> SourceB {
-    let args = ["cloud", "list", "--json", "--limit", "20"]
-    let result = runCommand("/usr/bin/env", ["codex"] + args, timeout: 30)
+private func measureSourceB() async -> SourceB {
+    let inventory = measureCloudTaskInventory()
+    var usage = SourceB(
+        command: inventory.command, exitCode: inventory.exitCode, wallMs: inventory.wallMs,
+        stdoutBytes: inventory.stdoutBytes, tasks: inventory.tasks,
+        taskFields: inventory.taskFields, usageBearingFields: inventory.usageBearingFields,
+        inventoryError: inventory.error,
+        usageCommand: "CodexCloudUsageProvider.fetch(days: 90)", usageWallMs: 0,
+        units: nil, days: 0, cloudDays: 0, cloudTotalPercent: 0, localTotalPercent: 0,
+        dayDetail: [], usageError: nil, calibration: [],
+        impliedTokensPerPercent: nil, cloudTokensEstimate: nil)
+
+    let start = DispatchTime.now().uptimeNanoseconds
+    do {
+        let report = try await CodexCloudUsageProvider.fetch(days: 90)
+        usage.usageWallMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0
+        usage.units = report.units
+        usage.days = report.days.count
+        usage.cloudDays = report.cloudDays
+        usage.cloudTotalPercent = report.cloudTotalPercent
+        usage.localTotalPercent = report.localTotalPercent
+        usage.dayDetail = report.days.filter {
+            $0.cloudPercent > 0 || $0.localPercent > 0
+        }.map { day in
+            var cloud: [String: Double] = [:]
+            var local: [String: Double] = [:]
+            for (surface, value) in day.surfaces where value > 0 {
+                if codexCloudSurfaces.contains(surface) {
+                    cloud[surface] = value
+                } else {
+                    local[surface] = value
+                }
+            }
+            return CloudDayPercent(
+                date: day.date, cloudPercent: day.cloudPercent,
+                localPercent: day.localPercent, cloudSurfaces: cloud, localSurfaces: local)
+        }
+    } catch {
+        usage.usageWallMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0
+        usage.usageError = "\(error)"
+    }
+
+    // Calibration: the account's percent for the local surfaces vs the tokens
+    // Tokcat parsed from the same days' local logs. A stable ratio would let a
+    // cloud percent be read as tokens; scatter means it cannot.
+    let localTokensByDate = localCodexTokensByDate()
+    var calibration: [CalibrationDay] = []
+    for day in usage.dayDetail where day.localPercent > 0 {
+        guard let tokens = localTokensByDate[day.date], tokens > 0 else { continue }
+        calibration.append(
+            CalibrationDay(
+                date: day.date, localPercent: day.localPercent, localTokens: tokens,
+                tokensPerPercent: Double(tokens) / day.localPercent))
+    }
+    usage.calibration = calibration
+    let ratios = calibration.map(\.tokensPerPercent).sorted()
+    if let median = ratios.isEmpty ? nil : ratios[ratios.count / 2] {
+        usage.impliedTokensPerPercent = median
+        usage.cloudTokensEstimate = Int64(usage.cloudTotalPercent * median)
+    }
+    return usage
+}
+
+private struct CloudTaskInventory {
+    var command: String
+    var exitCode: Int32?
+    var wallMs: Double
+    var stdoutBytes: Int
+    var tasks: Int
+    var taskFields: [String]
+    var usageBearingFields: [String]
+    var error: String?
+}
+
+private func measureCloudTaskInventory() -> CloudTaskInventory {
+    let result = runCommand("/usr/bin/env", ["codex", "cloud", "list", "--json", "--limit", "20"],
+        timeout: 30)
     guard let result else {
-        return SourceB(
+        return CloudTaskInventory(
             command: "codex cloud list --json --limit 20", exitCode: nil, wallMs: 0,
             stdoutBytes: 0, tasks: 0, taskFields: [], usageBearingFields: [],
-            detail: "codex not found or timed out")
+            error: "codex not found or timed out")
     }
     var fields: [String] = []
     var usageFields: [String] = []
@@ -325,15 +455,21 @@ private func measureSourceB() -> SourceB {
                 || lowered.contains("cost")
         }
     }
-    return SourceB(
+    return CloudTaskInventory(
         command: "codex cloud list --json --limit 20",
-        exitCode: result.exitCode,
-        wallMs: result.wallMs,
-        stdoutBytes: result.stdout.count,
-        tasks: tasks,
-        taskFields: fields,
-        usageBearingFields: usageFields,
-        detail: result.exitCode == 0 ? nil : String(data: result.stderr, encoding: .utf8))
+        exitCode: result.exitCode, wallMs: result.wallMs, stdoutBytes: result.stdout.count,
+        tasks: tasks, taskFields: fields, usageBearingFields: usageFields,
+        error: result.exitCode == 0 ? nil : String(data: result.stderr, encoding: .utf8))
+}
+
+/// Tokcat's own per-day codex tokens, for the calibration join.
+private func localCodexTokensByDate() -> [String: Int64] {
+    guard let payload = try? UsageGraph.run(year: "", clients: ["codex"]) else { return [:] }
+    var out: [String: Int64] = [:]
+    for contribution in payload.contributions {
+        out[contribution.date] = contribution.totals.tokens
+    }
+    return out
 }
 
 // MARK: - C. quota windows

--- a/native/LocalPackage/Sources/tokcat-dump/CloudProbe.swift
+++ b/native/LocalPackage/Sources/tokcat-dump/CloudProbe.swift
@@ -1,0 +1,403 @@
+// `tokcat-dump cloud-probe` — measures the three candidate sources for
+// cloud-session usage. Dev-only: nothing here ships in the app, it exists so
+// the numbers in the PR (and the eventual decision) are reproducible.
+//
+//   A. local transcripts   — classify cloud sessions inside `~/.claude/projects`
+//                            across the (marker × read) matrix
+//   B. cloud task list     — `codex cloud list --json` (local Codex auth)
+//   C. quota windows       — the OAuth usage endpoints Tokcat already calls
+//
+// Output is one JSON object on stdout.
+import Collector
+import DataSource
+import Foundation
+
+struct CloudProbeOutput: Encodable {
+    var measuredAt: String
+    var sourceA: SourceA
+    var sourceB: SourceB?
+    var sourceC: SourceC?
+
+    enum CodingKeys: String, CodingKey {
+        case measuredAt = "measured_at"
+        case sourceA = "source_a"
+        case sourceB = "source_b"
+        case sourceC = "source_c"
+    }
+}
+
+struct SourceA: Encodable {
+    var claudeParseWallMs: Double
+    var claudeParseMessages: Int
+    var claudeDays: Int
+    /// Ground truth: (cwdField, fullScan).
+    var truthTranscripts: [String]
+    var truthTokens: Int64
+    var rows: [MatrixRow]
+    var claudeDaily: [DailyTotals]
+    var share: [CloudShare]
+
+    enum CodingKeys: String, CodingKey {
+        case claudeParseWallMs = "claude_parse_wall_ms"
+        case claudeParseMessages = "claude_parse_messages"
+        case claudeDays = "claude_days"
+        case truthTranscripts = "truth_transcripts"
+        case truthTokens = "truth_tokens"
+        case rows
+        case claudeDaily = "claude_daily"
+        case share
+    }
+}
+
+/// One (marker, variant) cell of the matrix.
+struct MatrixRow: Encodable {
+    var marker: String
+    var variant: String
+    var headBytes: Int
+    var transcripts: Int
+    var tokens: Int64
+    var messages: Int
+    var cost: Double
+    /// Bytes read across all candidate transcripts.
+    var bytesRead: Int64
+    var candidateBytes: Int64
+    var wallMs: Double
+    var truePositives: Int
+    var falsePositives: Int
+    /// Accuracy is only meaningful when the ground-truth cell ran too.
+    var missed: Int?
+    var precision: Double?
+    var recall: Double?
+    /// Files the row flagged that ground truth did not.
+    var falsePositivePaths: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case marker, variant, transcripts, tokens, messages, cost, precision, recall, missed
+        case headBytes = "head_bytes"
+        case bytesRead = "bytes_read"
+        case candidateBytes = "candidate_bytes"
+        case wallMs = "wall_ms"
+        case truePositives = "true_positives"
+        case falsePositives = "false_positives"
+        case falsePositivePaths = "false_positive_paths"
+    }
+}
+
+struct DailyTotals: Encodable {
+    var date: String
+    var tokens: Int64
+    var messages: Int
+    var cost: Double
+}
+
+struct CloudShare: Encodable {
+    var date: String
+    var cloudTokens: Int64
+    var claudeTokens: Int64
+    var share: Double
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case cloudTokens = "cloud_tokens"
+        case claudeTokens = "claude_tokens"
+        case share
+    }
+}
+
+struct SourceB: Encodable {
+    var command: String
+    var exitCode: Int32?
+    var wallMs: Double
+    var stdoutBytes: Int
+    var tasks: Int
+    var taskFields: [String]
+    var usageBearingFields: [String]
+    var detail: String?
+
+    enum CodingKeys: String, CodingKey {
+        case command
+        case exitCode = "exit_code"
+        case wallMs = "wall_ms"
+        case stdoutBytes = "stdout_bytes"
+        case tasks
+        case taskFields = "task_fields"
+        case usageBearingFields = "usage_bearing_fields"
+        case detail
+    }
+}
+
+struct SourceC: Encodable {
+    var claude: AgentUsageSnapshot?
+    var claudeWallMs: Double
+    var codex: AgentUsageSnapshot?
+    var codexWallMs: Double
+    var perDayTokenSeries: Bool
+    var note: String
+
+    enum CodingKeys: String, CodingKey {
+        case claude
+        case claudeWallMs = "claude_wall_ms"
+        case codex
+        case codexWallMs = "codex_wall_ms"
+        case perDayTokenSeries = "per_day_token_series"
+        case note
+    }
+}
+
+func runCloudProbe(days: Int, only: [String], skipNetwork: Bool) {
+    // URLSession needs the concurrency runtime alive, so run the whole probe
+    // in a detached task and hold the CLI open, same shape as `tail-sim`.
+    let semaphore = DispatchSemaphore(value: 0)
+    Task.detached {
+        let output = CloudProbeOutput(
+            measuredAt: ISO8601DateFormatter().string(from: Date()),
+            sourceA: measureSourceA(days: days, only: only),
+            sourceB: skipNetwork ? nil : measureSourceB(),
+            sourceC: skipNetwork ? nil : await measureSourceC())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        do {
+            let data = try encoder.encode(output)
+            FileHandle.standardOutput.write(data)
+            FileHandle.standardOutput.write(Data("\n".utf8))
+        } catch {
+            fail("encode cloud-probe output: \(error)", code: 1)
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+}
+
+/// `--only marker:variant[:headBytes]` — restrict the matrix so each cell can
+/// be measured in its own process (`/usr/bin/time -l` reports process totals,
+/// which a combined run hides).
+private func parseOnly(_ specs: [String]) -> [MatrixCell]? {
+    guard !specs.isEmpty else { return nil }
+    var cells: [MatrixCell] = []
+    for spec in specs {
+        let parts = spec.split(separator: ":").map(String.init)
+        guard parts.count >= 2,
+            let marker = CloudMarker(rawValue: parts[0]),
+            let variant = CloudScanVariant(rawValue: parts[1])
+        else {
+            fail("--only expects marker:variant[:headBytes], got \(spec)")
+        }
+        let head = parts.count > 2 ? Int(parts[2]) ?? 8 * 1024 : 8 * 1024
+        cells.append(MatrixCell(marker: marker, variant: variant, headBytes: head))
+    }
+    return cells
+}
+
+// MARK: - A. local transcripts
+
+private struct MatrixCell {
+    var marker: CloudMarker
+    var variant: CloudScanVariant
+    var headBytes: Int
+}
+
+private let matrix: [MatrixCell] = [
+    // Zero-read path classification.
+    MatrixCell(marker: .pathSlug, variant: .noRead, headBytes: 0),
+    // Structured cwd, small and larger head budgets, then the ground truth.
+    MatrixCell(marker: .cwdField, variant: .headSniff, headBytes: 8 * 1024),
+    MatrixCell(marker: .cwdField, variant: .headSniff, headBytes: 64 * 1024),
+    MatrixCell(marker: .cwdField, variant: .fullScan, headBytes: 0),
+    // Raw substring: cheap, but quotes in shell output look identical.
+    MatrixCell(marker: .rawSubstring, variant: .headSniff, headBytes: 8 * 1024),
+    MatrixCell(marker: .rawSubstring, variant: .fullScan, headBytes: 0),
+    // The loose bridge-id marker, for the over-attribution cost.
+    MatrixCell(marker: .bridgeSessionID, variant: .headSniff, headBytes: 8 * 1024),
+    MatrixCell(marker: .bridgeSessionID, variant: .fullScan, headBytes: 0),
+]
+
+private func measureSourceA(days: Int, only: [String]) -> SourceA {
+    let cells = parseOnly(only) ?? matrix
+    let parseStart = DispatchTime.now().uptimeNanoseconds
+    let claude = try? UsageGraph.run(year: "", clients: ["claude"])
+    let parseMs = Double(DispatchTime.now().uptimeNanoseconds - parseStart) / 1_000_000.0
+
+    var reports: [CloudScanReport] = []
+    for cell in cells {
+        reports.append(
+            CloudSessionScanner.scan(
+                marker: cell.marker, variant: cell.variant, headBytes: cell.headBytes))
+    }
+    let truthReport = reports.first {
+        $0.marker == .cwdField && $0.variant == .fullScan
+    }
+    let truthPaths = Set(truthReport?.transcripts.map(\.path) ?? [])
+    let truthTokens = truthReport?.totalTokens ?? 0
+    let truthMeasured = reports.contains {
+        $0.marker == .cwdField && $0.variant == .fullScan
+    }
+
+    let rows = zip(cells, reports).map { cell, report -> MatrixRow in
+        let paths = report.transcripts.map(\.path)
+        let flagged = Set(paths)
+        let falsePositives = flagged.subtracting(truthPaths).sorted()
+        let truePositives = flagged.intersection(truthPaths).count
+        return MatrixRow(
+            marker: cell.marker.rawValue,
+            variant: cell.variant.rawValue,
+            headBytes: cell.headBytes,
+            transcripts: paths.count,
+            tokens: report.totalTokens,
+            messages: report.totalMessages,
+            cost: report.totalCost,
+            bytesRead: report.bytesRead,
+            candidateBytes: report.candidateBytes,
+            wallMs: report.wallMs,
+            truePositives: truePositives,
+            falsePositives: falsePositives.count,
+            missed: truthMeasured ? truthPaths.subtracting(flagged).count : nil,
+            precision: truthMeasured
+                ? (paths.isEmpty ? 0 : Double(truePositives) / Double(paths.count)) : nil,
+            recall: truthMeasured
+                ? (truthPaths.isEmpty ? 1 : Double(truePositives) / Double(truthPaths.count))
+                : nil,
+            falsePositivePaths: falsePositives)
+    }
+
+    // Every day the plain claude graph knows about, so the cloud share is
+    // comparable instead of silently zero outside the recent window.
+    var claudeTokensByDate: [String: Int64] = [:]
+    var claudeDaily: [DailyTotals] = []
+    for contribution in claude?.contributions ?? [] {
+        claudeTokensByDate[contribution.date] = contribution.totals.tokens
+    }
+    for contribution in (claude?.contributions ?? []).suffix(days) {
+        claudeDaily.append(
+            DailyTotals(
+                date: contribution.date,
+                tokens: contribution.totals.tokens,
+                messages: Int(contribution.totals.messages),
+                cost: contribution.totals.cost))
+    }
+    let share = (truthReport?.daily ?? []).compactMap { day -> CloudShare? in
+        guard let claudeTokens = claudeTokensByDate[day.date], claudeTokens > 0 else {
+            return nil
+        }
+        return CloudShare(
+            date: day.date,
+            cloudTokens: day.tokens,
+            claudeTokens: claudeTokens,
+            share: Double(day.tokens) / Double(claudeTokens))
+    }
+
+    return SourceA(
+        claudeParseWallMs: parseMs,
+        claudeParseMessages: Int((claude?.contributions ?? []).reduce(Int64(0)) {
+            $0 + $1.totals.messages
+        }),
+        claudeDays: claude?.contributions.count ?? 0,
+        truthTranscripts: truthPaths.sorted(),
+        truthTokens: truthTokens,
+        rows: rows,
+        claudeDaily: claudeDaily,
+        share: share)
+}
+
+// MARK: - B. codex cloud task list
+
+private func measureSourceB() -> SourceB {
+    let args = ["cloud", "list", "--json", "--limit", "20"]
+    let result = runCommand("/usr/bin/env", ["codex"] + args, timeout: 30)
+    guard let result else {
+        return SourceB(
+            command: "codex cloud list --json --limit 20", exitCode: nil, wallMs: 0,
+            stdoutBytes: 0, tasks: 0, taskFields: [], usageBearingFields: [],
+            detail: "codex not found or timed out")
+    }
+    var fields: [String] = []
+    var usageFields: [String] = []
+    var tasks = 0
+    if let json = try? JSONSerialization.jsonObject(with: result.stdout) as? [String: Any] {
+        if let list = json["tasks"] as? [[String: Any]] {
+            tasks = list.count
+            var keys = Set<String>()
+            for task in list { keys.formUnion(task.keys) }
+            fields = keys.sorted()
+        }
+        usageFields = fields.filter {
+            let lowered = $0.lowercased()
+            return lowered.contains("token") || lowered.contains("usage")
+                || lowered.contains("cost")
+        }
+    }
+    return SourceB(
+        command: "codex cloud list --json --limit 20",
+        exitCode: result.exitCode,
+        wallMs: result.wallMs,
+        stdoutBytes: result.stdout.count,
+        tasks: tasks,
+        taskFields: fields,
+        usageBearingFields: usageFields,
+        detail: result.exitCode == 0 ? nil : String(data: result.stderr, encoding: .utf8))
+}
+
+// MARK: - C. quota windows
+
+private func measureSourceC() async -> SourceC {
+    let claudeStart = DispatchTime.now().uptimeNanoseconds
+    let claude: AgentUsageSnapshot? = await ClaudeQuotaProvider.fetch()
+    let claudeMs = Double(DispatchTime.now().uptimeNanoseconds - claudeStart) / 1_000_000.0
+    let codexStart = DispatchTime.now().uptimeNanoseconds
+    let codex: AgentUsageSnapshot? = await CodexQuotaProvider.fetch()
+    let codexMs = Double(DispatchTime.now().uptimeNanoseconds - codexStart) / 1_000_000.0
+    // Both endpoints answer with window utilization (`used_percent`) and a
+    // reset instant. Neither returns tokens, and neither carries a per-day
+    // series, so nothing here can be summed into a daily token graph.
+    let note = """
+        Claude/Codex usage endpoints report window utilization (percent + reset), \
+        not tokens. A per-day cloud total would have to be inferred from \
+        utilization deltas against an undisclosed plan budget.
+        """
+    return SourceC(
+        claude: claude, claudeWallMs: claudeMs,
+        codex: codex, codexWallMs: codexMs,
+        perDayTokenSeries: false, note: note)
+}
+
+// MARK: - subprocess
+
+private struct CommandResult {
+    var exitCode: Int32
+    var stdout: Data
+    var stderr: Data
+    var wallMs: Double
+}
+
+private func runCommand(
+    _ launchPath: String, _ arguments: [String], timeout: Double
+) -> CommandResult? {
+    guard FileManager.default.isExecutableFile(atPath: launchPath) else { return nil }
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: launchPath)
+    process.arguments = arguments
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+    let start = DispatchTime.now().uptimeNanoseconds
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+    let deadline = Date().addingTimeInterval(timeout)
+    while process.isRunning && Date() < deadline {
+        usleep(20_000)
+    }
+    if process.isRunning {
+        process.terminate()
+        return nil
+    }
+    let out = (try? stdout.fileHandleForReading.readToEnd()) ?? Data()
+    let err = (try? stderr.fileHandleForReading.readToEnd()) ?? Data()
+    return CommandResult(
+        exitCode: process.terminationStatus,
+        stdout: out,
+        stderr: err,
+        wallMs: Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0)
+}

--- a/native/LocalPackage/Sources/tokcat-dump/main.swift
+++ b/native/LocalPackage/Sources/tokcat-dump/main.swift
@@ -13,6 +13,10 @@
 //   tokcat-dump tail-live [--ticks N] [--window-secs N]
 //     dev smoke: runs the live tailer against the real environment for N
 //     ticks (5s apart) and prints the observed rates.
+//   tokcat-dump cloud-probe [--days N]
+//     dev measurement: compares the three candidate sources for cloud-session
+//     usage (local transcripts, `codex cloud list`, quota windows) and prints
+//     the per-source numbers as JSON. See Collector/CloudSessions.swift.
 import Collector
 import DataSource
 import Foundation
@@ -26,6 +30,7 @@ let usageText = """
 usage: tokcat-dump graph [--year YYYY] [--clients a,b]
        tokcat-dump tail-sim --dir DIR [--window-secs N] [--now-ms N]
        tokcat-dump tail-live [--ticks N] [--window-secs N]
+       tokcat-dump cloud-probe [--days N]
 """
 
 var args = Array(CommandLine.arguments.dropFirst())
@@ -214,6 +219,28 @@ case "tail-live":
         semaphore.signal()
     }
     semaphore.wait()
+
+case "cloud-probe":
+    var days = 14
+    var only: [String] = []
+    var skipNetwork = false
+    var i = 0
+    while i < args.count {
+        switch args[i] {
+        case "--days":
+            days = Int(intFlag("--days", args, &i))
+        case "--only":
+            i += 1
+            guard i < args.count else { fail("--only requires marker:variant[:headBytes]") }
+            only.append(args[i])
+        case "--no-network":
+            skipNetwork = true
+        default:
+            fail("unknown arg: \(args[i])")
+        }
+        i += 1
+    }
+    runCloudProbe(days: max(days, 1), only: only, skipNetwork: skipNetwork)
 
 default:
     fail(usageText)

--- a/native/LocalPackage/Tests/CollectorTests/CloudSessionTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/CloudSessionTests.swift
@@ -1,0 +1,152 @@
+import DataSource
+import Foundation
+import Testing
+
+@testable import Collector
+
+// Pins the cloud-session marker semantics measured by `tokcat-dump cloud-probe`:
+// a bridged cloud session is recognizable from its worktree path (`cwd` or the
+// project-directory slug), while two cheap-looking substitutes over-match —
+// raw substrings hit transcripts that merely print the path, and `cse_`
+// bridge ids also appear on ordinary sessions the Claude app bridges locally.
+
+private func makeCloudTempDir(_ name: String) throws -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent(
+            "tokcat-cloud-\(name)-\(ProcessInfo.processInfo.processIdentifier)"
+                + "-\(UInt32.random(in: 0..<UInt32.max))")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+private let cloudWorktreePath = "/Users/dev/repo/.claude/worktrees/bridge-cse_01TSxYxjq9U4HGAkv3TCv8He"
+
+/// A transcript with one assistant usage row (3 input + 5 output tokens).
+private func assistantRow(timestamp: String, id: String, requestId: String) -> String {
+    """
+    {"type":"assistant","timestamp":"\(timestamp)","requestId":"\(requestId)",\
+    "message":{"id":"\(id)","model":"claude-opus-5",\
+    "usage":{"input_tokens":3,"output_tokens":5,"cache_read_input_tokens":0,\
+    "cache_creation_input_tokens":0}}}
+    """
+}
+
+private func writeTranscript(_ root: URL, slug: String, name: String, lines: [String]) throws
+    -> String
+{
+    let dir = root.appendingPathComponent(".claude/projects/\(slug)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let path = dir.appendingPathComponent("\(name).jsonl").path
+    try (lines.joined(separator: "\n") + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+    return path
+}
+
+@Suite struct CloudSessionMarkerTests {
+    /// The one shape that is a cloud session: worktree cwd + `cse_` bridge id.
+    private func withCloudFixture(_ body: (URL) throws -> Void) throws {
+        let root = try makeCloudTempDir("fixture")
+        defer { try? FileManager.default.removeItem(at: root) }
+        _ = try writeTranscript(
+            root,
+            slug: "-Users-dev-repo--claude-worktrees-bridge-cse-01TSxYxjq9U4HGAkv3TCv8He",
+            name: "cloud",
+            lines: [
+                #"{"type":"bridge-session","sessionId":"a","bridgeSessionId":"cse_01TSxYxjq9U4HGAkv3TCv8He"}"#,
+                #"{"type":"attachment","cwd":"\#(cloudWorktreePath)"}"#,
+                assistantRow(timestamp: "2026-08-30T12:00:00.000Z", id: "m1", requestId: "r1"),
+            ])
+        // A local session that only *prints* the worktree path (git worktree
+        // list output) and carries a bridge id without the cloud prefix.
+        _ = try writeTranscript(
+            root,
+            slug: "-Users-dev-repo",
+            name: "local-mention",
+            lines: [
+                #"{"type":"bridge-session","sessionId":"b","bridgeSessionId":"session_014rBZWSJ5KV8TzstZ6pJgdE"}"#,
+                #"{"type":"attachment","cwd":"/Users/dev/repo","toolUseResult":"\#(cloudWorktreePath)"}"#,
+                assistantRow(timestamp: "2026-08-30T13:00:00.000Z", id: "m2", requestId: "r2"),
+            ])
+        // A local session the Claude app bridges: `cse_` id, local cwd.
+        _ = try writeTranscript(
+            root,
+            slug: "-Users-dev-other",
+            name: "local-bridged",
+            lines: [
+                #"{"type":"bridge-session","sessionId":"c","bridgeSessionId":"cse_016BWdJQ3gszk8FoVveLLZnJ"}"#,
+                #"{"type":"attachment","cwd":"/Users/dev/other"}"#,
+                assistantRow(timestamp: "2026-08-30T14:00:00.000Z", id: "m3", requestId: "r3"),
+            ])
+        try body(root)
+    }
+
+    @Test func pathSlugNeedsNoReads() throws {
+        try withCloudFixture { root in
+            let report = CloudSessionScanner.scan(
+                marker: .pathSlug, variant: .noRead, home: root.path)
+            #expect(report.transcripts.count == 1)
+            #expect(report.transcripts.first?.path.contains("bridge-cse") == true)
+            #expect(report.bytesRead == 0)
+            #expect(report.totalTokens == 8)
+        }
+    }
+
+    @Test func cwdFieldIgnoresTranscriptsThatMerelyMentionThePath() throws {
+        try withCloudFixture { root in
+            for variant in [CloudScanVariant.headSniff, .fullScan] {
+                let report = CloudSessionScanner.scan(
+                    marker: .cwdField, variant: variant, home: root.path)
+                #expect(report.transcripts.count == 1, "variant \(variant)")
+                #expect(report.totalTokens == 8, "variant \(variant)")
+            }
+        }
+    }
+
+    @Test func rawSubstringOverMatchesQuotedPaths() throws {
+        try withCloudFixture { root in
+            let report = CloudSessionScanner.scan(
+                marker: .rawSubstring, variant: .fullScan, home: root.path)
+            // The `git worktree list` output in the local session counts as a hit.
+            #expect(report.transcripts.count == 2)
+            #expect(report.totalTokens == 16)
+        }
+    }
+
+    @Test func bridgeSessionIDOverMatchesLocallyBridgedSessions() throws {
+        try withCloudFixture { root in
+            let report = CloudSessionScanner.scan(
+                marker: .bridgeSessionID, variant: .fullScan, home: root.path)
+            // All three sessions carry a bridge id; only one is a cloud session.
+            #expect(report.transcripts.count == 3)
+            #expect(report.totalTokens == 24)
+        }
+    }
+
+    /// The head budget decides recall for content markers: a marker that only
+    /// appears past the budget is invisible to `.headSniff`.
+    @Test func headSniffMissesMarkersBeyondTheBudget() throws {
+        let root = try makeCloudTempDir("head-budget")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let padding = String(repeating: "x", count: 4096)
+        _ = try writeTranscript(
+            root,
+            slug: "-Users-dev-repo--claude-worktrees-bridge-cse-01TSxYxjq9U4HGAkv3TCv8He",
+            name: "late-marker",
+            lines: [
+                #"{"type":"attachment","cwd":"/Users/dev/repo","note":"\#(padding)"}"#,
+                #"{"type":"attachment","cwd":"\#(cloudWorktreePath)"}"#,
+                assistantRow(timestamp: "2026-08-30T12:00:00.000Z", id: "m1", requestId: "r1"),
+            ])
+        // The slug still finds it with zero reads; the content scan does not
+        // once the cwd row sits past the configured head.
+        #expect(
+            CloudSessionScanner.scan(marker: .pathSlug, variant: .noRead, home: root.path)
+                .transcripts.count == 1)
+        #expect(
+            CloudSessionScanner.scan(
+                marker: .cwdField, variant: .headSniff, headBytes: 1024, home: root.path
+            ).transcripts.isEmpty)
+        #expect(
+            CloudSessionScanner.scan(marker: .cwdField, variant: .fullScan, home: root.path)
+                .transcripts.count == 1)
+    }
+}

--- a/native/LocalPackage/Tests/CollectorTests/CodexCloudUsageTests.swift
+++ b/native/LocalPackage/Tests/CollectorTests/CodexCloudUsageTests.swift
@@ -1,0 +1,103 @@
+import DataSource
+import Foundation
+import Testing
+
+@testable import Collector
+
+// Pins the Codex Cloud daily-usage decode: plan percent per day, split into
+// cloud surfaces (this is not the Mac) vs local ones (Tokcat already parses
+// those from disk, so counting them again would double count).
+
+@Suite struct CodexCloudUsageTests {
+    private let wire = """
+        {
+          "units": "percent",
+          "group_by": "day",
+          "data": [
+            {
+              "date": "2026-09-05",
+              "product_surface_usage_values": {
+                "cli": 0.0, "vscode": 0.0, "web": 0.024, "mobile": 0.0,
+                "desktop_app": 31.972, "agent_identity": 0.487, "unknown": 0.0
+              },
+              "models": [
+                {"model": "gpt-6-astra", "speed": "standard", "credits": 31.257}
+              ]
+            },
+            {
+              "date": "2026-09-06",
+              "product_surface_usage_values": {"desktop_app": 100.0},
+              "models": []
+            }
+          ]
+        }
+        """
+
+    private func decode(_ json: String) throws -> CodexDailyUsageResponse {
+        try JSONDecoder().decode(CodexDailyUsageResponse.self, from: Data(json.utf8))
+    }
+
+    @Test func splitsCloudFromLocalSurfaces() throws {
+        let report = CodexCloudUsageProvider.report(from: try decode(wire))
+        #expect(report.units == "percent")
+        #expect(report.days.count == 2)
+        #expect(report.cloudDays == 1)
+        // web 0.024 + agent_identity 0.487
+        #expect(abs(report.days[0].cloudPercent - 0.511) < 1e-9)
+        #expect(abs(report.days[0].localPercent - 31.972) < 1e-9)
+        #expect(abs(report.days[1].cloudPercent) < 1e-12)
+        #expect(abs(report.days[1].localPercent - 100.0) < 1e-9)
+        #expect(abs(report.cloudTotalPercent - 0.511) < 1e-9)
+        #expect(abs(report.localTotalPercent - 131.972) < 1e-9)
+    }
+
+    @Test func keepsModelRows() throws {
+        let report = CodexCloudUsageProvider.report(from: try decode(wire))
+        #expect(report.days[0].models.count == 1)
+        #expect(report.days[0].models[0].model == "gpt-6-astra")
+        #expect(abs(report.days[0].models[0].credits - 31.257) < 1e-9)
+    }
+
+    /// A surface we have never seen must land in the local bucket rather than
+    /// failing the decode — a new server surface should not break refresh.
+    @Test func unknownSurfaceDoesNotFailDecode() throws {
+        let json = """
+            {"units":"percent","group_by":"day","data":[
+              {"date":"2026-09-05","product_surface_values_missing":true}
+            ]}
+            """
+        let report = CodexCloudUsageProvider.report(from: try decode(json))
+        #expect(report.days.count == 1)
+        #expect(report.days[0].surfaces.isEmpty)
+        #expect(report.cloudDays == 0)
+
+        let extra = """
+            {"units":"percent","group_by":"day","data":[
+              {"date":"2026-09-05","product_surface_usage_values":{"some_new_thing":2.5},
+               "models":[{"model":"gpt-6-astra","speed":"standard","credits":null}]}
+            ]}
+            """
+        let newSurface = CodexCloudUsageProvider.report(from: try decode(extra))
+        #expect(abs(newSurface.days[0].localPercent - 2.5) < 1e-9)
+        #expect(newSurface.days[0].models[0].credits == 0)
+    }
+
+    @Test func daysAreSortedByDate() throws {
+        let json = """
+            {"units":"percent","group_by":"day","data":[
+              {"date":"2026-09-07","product_surface_usage_values":{"web":1},"models":[]},
+              {"date":"2026-09-01","product_surface_usage_values":{"web":2},"models":[]}
+            ]}
+            """
+        let report = CodexCloudUsageProvider.report(from: try decode(json))
+        #expect(report.days.map(\.date) == ["2026-09-01", "2026-09-07"])
+    }
+
+    @Test func dateStringIsUTC() {
+        // 2026-09-13T00:30:00+09:00 is 2026-09-12T15:30:00Z.
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let date = formatter.date(from: "2026-09-12T15:30:00Z")!
+        #expect(CodexCloudUsageProvider.dateString(date) == "2026-09-12")
+    }
+}


### PR DESCRIPTION
Claude Code cloud sessions and Codex Cloud tasks are showing up more often and neither is visible in the graph today. This PR measures both: which source is accurate, what it costs, and — after chasing the Codex side down — **what each can actually yield**. No app behavior changes yet; the decision comes next.

## Codex Cloud: reachable, but percent — not tokens

Started from the two dead ends:

| probe | result |
| --- | --- |
| `codex cloud list --json` | exit 0, 782 ms, **4 tasks**, fields `attempt_total, environment_id, environment_label, id, is_review, status, summary, title, updated_at, url` — **no usage field** |
| `POST /wham/usage/thread_usage/query` (per-thread usage) | **403** with the CLI's OAuth token (v2 → 404); adding the app's `Origin`/`Referer`/beta headers does not change it |
| `GET /wham/tasks/{id}/turns/{turn}/logs` | `{"logs": []}` |
| `GET /wham/usage/credit-usage-events` | `{"data": []}` |
| `GET /wham/usage/plan_limit_history` | 404 |
| `GET /wham/usage/daily-workspace-user-token-usage-breakdown` | 400 — `No active workspace found for the current account` (business/workspace variant) |

The route list came from ChatGPT.app's `app.asar`, which also gave the call shape the app itself uses:

```js
safeGet('/wham/usage/daily-token-usage-breakdown',
  {parameters: {query: {start_date, end_date, group_by: 'day'}}})
```

That one works with local credentials, and it is implemented here as `CodexCloudUsageProvider`:

| measurement | value |
| --- | --- |
| wall time | **869 ms** (1 GET, existing credential + refresh path) |
| response | 90 days for a 90-day range; `units: "percent"`, `group_by: "day"` |
| shape | `data[].product_surface_usage_values` — per-day plan percent **split by where the work ran** |
| cloud surfaces | `web`, `work_web`, `mobile`, `work_mobile`, `slack`, `linear`, `jetbrains`, `github`, `github_code_review`, `agent_identity`, `sdk` |
| local surfaces | `cli`, `vscode`, `desktop_app`, `exec`, `unknown` (this Mac — Tokcat already parses these from disk) |
| 90-day totals on this account | cloud **0.5112 %**, local **135.367 %** |
| cloud non-zero days | **1** — 2026-09-05: `web` 0.024 %, `agent_identity` 0.487 % |

So Codex Cloud usage **is** retrievable per day, and the cloud/local split is exactly what a cloud row would need — but the unit is plan percent. Reading it as tokens is not defensible: calibrating "tokens per percent" against days where both the account's local percent and Tokcat's local token count exist gives

| day | local percent | local tokens (Tokcat) | tokens / percent |
| --- | --- | --- | --- |
| 2026-06-18 | 0.243 | 1,224,770 | 5.04 M |
| 2026-09-05 | 31.972 | 4,092,946 | 0.128 M |
| 2026-09-06 | 100.000 | 293,018,446 | 2.93 M |
| 2026-09-07 | 1.374 | 181,697,807 | 132.2 M |
| 2026-09-11 | 1.702 | 5,351,981 | 3.14 M |

a **1000× spread** across five days (and 2026-09-06 sits at exactly `100.000`, so the percent is bounded/capped rather than a linear share). Any "cloud tokens" figure derived from it would be invention.

## Claude cloud: tokens, but almost nothing on disk

The updated marker × read matrix (ground truth = `cwdField` + `fullScan`; 1,093 candidate transcripts, 472.9 MB):

| marker | read | files | false pos | precision | recall | MB read | probe wall | tokens attributed |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `pathSlug` | none | 1 | 0 | 1.00 | 1.00 | **0.0** | **0.21 s** | 16,971 |
| `cwdField` | head 8 KB | 1 | 0 | 1.00 | 1.00 | 6.7 | 0.38 s | 16,971 |
| `cwdField` | head 64 KB | 1 | 0 | 1.00 | 1.00 | 50.4 | 1.2 s | 16,971 |
| `cwdField` | full scan | 1 | 0 | 1.00 | 1.00 | 473.4 | 6.9 s | 16,971 |
| `rawSubstring` | full scan | 4 | **3** | **0.25** | 1.00 | 473.4 | 11.2 s | 67.1 M (56.6 M wrong) |
| `bridgeSessionID` | full scan | 55 | **55** | **0.00** | 0.00 | 473.4 | 6.0 s | 406.2 M |

Two traps the tests now pin: raw substrings catch transcripts that merely *print* the worktree path (`git worktree list` output, an `ls` error), and `bridgeSessionId: cse_…` appears on 55 ordinary locally bridged sessions, not just cloud ones. Parsing the `cwd` **value** removes both.

Coverage is the real limit: exactly one cloud transcript is visible locally (2026-08-30, **16,971 tokens = 0.022 %** of that day's 78.6 M claude tokens), against **10** cloud sessions this repo's harness has fired. A transcript only exists when a Remote Control bridge was registered at fire time.

## Yield summary

| source | what it yields | accuracy | cost |
| --- | --- | --- | --- |
| Claude local transcripts (`pathSlug`) | real tokens, daily — 16,971 tokens, 1 session | exact, precision/recall 1.00 locally; ~10 % of cloud sessions reach disk | 0 bytes read, +0.21 s |
| Codex `daily-token-usage-breakdown` | plan **percent** per day, cloud/local split — 1 cloud day in 90 | exact as served; not tokens (1000× calibration spread) | 869 ms, 1 GET + credential path |
| Codex `cloud list --json` | task inventory only (4 tasks) | exact, no usage | 782 ms, subprocess + network |
| percent → tokens estimate | nothing defensible | **rejected** | — |

Recommendation: wire the Claude split into the graph (`pathSlug`, exact, free) so bridged cloud sessions stop hiding inside `claude`, and surface the Codex cloud percent where plan percent already lives (the limits card) — not in the token graph, where it would have to be invented. If the per-thread token endpoint ever opens up (`thread_usage/query_v2` returning instead of 403/404), that becomes the Codex token source; the probe already prints what it returns.

## Verification

- `swift build && swift test` — **281 tests, 49 suites**, pass (`CloudSessionMarkerTests`, `CodexCloudUsageTests`).
- `scripts/parity-check.sh --snapshot` — **PASS** (collector stays bit-compatible with the Rust side).
- Reproduce: `cd native/LocalPackage && swift build && ./.build/debug/tokcat-dump cloud-probe --days 14`; per-cell resources with `--no-network --only <marker>:<variant>[:headBytes]` under `/usr/bin/time -l`.
- Endpoint shapes were read out of ChatGPT.app's `app.asar` (`/wham/usage/daily-token-usage-breakdown`, `thread_usage/query_v2`) and confirmed against the live API with the account's own credentials (read-only GETs).
